### PR TITLE
feat(clipboard): add ClipboardStatus component and usage example in docs

### DIFF
--- a/apps/patherns/src/examples/clipboard/clipboard-basics.tsx
+++ b/apps/patherns/src/examples/clipboard/clipboard-basics.tsx
@@ -3,9 +3,11 @@ import { Clipboard } from '@snaps-ui/react/clipboard'
 export default function ClipboardBasics() {
   return (
     <Clipboard.Root value="https://snaps-ui.vercel.app/">
-      <Clipboard.Trigger>
-        <Clipboard.Indicator />
-      </Clipboard.Trigger>
+      <Clipboard.Control>
+        <Clipboard.Trigger>
+          <Clipboard.Indicator />
+        </Clipboard.Trigger>
+      </Clipboard.Control>
     </Clipboard.Root>
   )
 }

--- a/apps/patherns/src/examples/clipboard/clipboard-with-status-text.tsx
+++ b/apps/patherns/src/examples/clipboard/clipboard-with-status-text.tsx
@@ -1,0 +1,16 @@
+import { Button, Clipboard } from '@snaps-ui/react'
+
+export default function ClipboardWithStatusText() {
+  return (
+    <Clipboard.Root value="https://snaps-ui.vercel.app/">
+      <Clipboard.Control>
+        <Clipboard.Trigger asChild>
+          <Button>
+            <Clipboard.Indicator />
+            <Clipboard.Status />
+          </Button>
+        </Clipboard.Trigger>
+      </Clipboard.Control>
+    </Clipboard.Root>
+  )
+}

--- a/apps/patherns/src/examples/clipboard/clipboard-with-timer.tsx
+++ b/apps/patherns/src/examples/clipboard/clipboard-with-timer.tsx
@@ -3,9 +3,11 @@ import { Clipboard } from '@snaps-ui/react'
 export default function ClipboardWithTimer() {
   return (
     <Clipboard.Root value="https://snaps-ui.vercel.app/" timeout={2000}>
-      <Clipboard.Trigger>
-        <Clipboard.Indicator />
-      </Clipboard.Trigger>
+      <Clipboard.Control>
+        <Clipboard.Trigger>
+          <Clipboard.Indicator />
+        </Clipboard.Trigger>
+      </Clipboard.Control>
     </Clipboard.Root>
   )
 }

--- a/apps/website/app/global.css
+++ b/apps/website/app/global.css
@@ -19,19 +19,7 @@ pre.shiki {
 .doc-container {
   padding-top: 2rem;
 
-  & > h3,
-  h2 {
-    font-size: 24px;
-    margin-bottom: 10px;
-  }
-
-  h3 {
-    font-size: 18px;
-  }
-
   a {
-    color: var(--colors-color-palette-default);
-
     &:hover {
       text-decoration: underline;
     }

--- a/apps/website/components/mdx-content.tsx
+++ b/apps/website/components/mdx-content.tsx
@@ -10,10 +10,14 @@ import { Callout } from '~/components/mdx/callout'
 import { Anchor } from '~/components/mdx/anchor'
 import { Code, Pre } from '~/components/mdx/code'
 import { CodeBlock } from '~/components/mdx/code-block'
-import { P, Strong } from './mdx/typography'
+import { H1, H2, H3, H4, P, Strong } from '~/components/mdx/typography'
 
 const sharedComponents = {
   a: Anchor,
+  h1: H1,
+  h2: H2,
+  h3: H3,
+  h4: H4,
   kbd: Kbd,
   pre: Pre,
   code: Code,

--- a/apps/website/components/mdx/typography.tsx
+++ b/apps/website/components/mdx/typography.tsx
@@ -30,3 +30,86 @@ export const Strong = (props: BoxProps) => {
     />
   )
 }
+
+export const H1 = (props: BoxProps) => {
+  return (
+    <Box
+      as="h1"
+      css={{
+        color: 'fg.muted',
+        fontSize: '1.5em',
+        letterSpacing: '-0.02em',
+        marginTop: '0',
+        marginBottom: '0.8em',
+        lineHeight: '1.2em',
+        fontWeight: 'medium',
+        scrollMarginTop: 'calc(var(--header-height) + 1.5em)',
+      }}
+      {...props}
+    />
+  )
+}
+
+export const H2 = (props: BoxProps) => {
+  return (
+    <Box
+      as="h2"
+      css={{
+        color: 'fg.muted',
+        fontSize: '1.3em',
+        letterSpacing: '-0.02em',
+        marginTop: '1.6em',
+        marginBottom: '0.8em',
+        lineHeight: '1.4em',
+        fontWeight: 'semibold',
+        scrollMarginTop: 'calc(var(--header-height) + 1.5em)',
+        '& code': { fontSize: '0.9em' },
+        '& + *': { marginTop: '0' },
+        '& a': { font: 'inherit!' },
+      }}
+      {...props}
+    />
+  )
+}
+
+export const H3 = (props: BoxProps) => {
+  return (
+    <Box
+      as="h3"
+      css={{
+        color: 'fg.muted',
+        fontSize: '1.2em',
+        letterSpacing: '-0.01em',
+        marginTop: '1.5em',
+        marginBottom: '0.4em',
+        fontWeight: 'semibold',
+        lineHeight: '1.5em',
+        scrollMarginTop: 'calc(var(--header-height) + 1.5em)',
+        '& code': { fontSize: '0.9em' },
+        '& + *': { marginTop: '0' },
+        '& a': { font: 'inherit!' },
+      }}
+      {...props}
+    />
+  )
+}
+
+export const H4 = (props: BoxProps) => {
+  return (
+    <Box
+      as="h4"
+      css={{
+        color: 'fg.muted',
+        marginTop: '2em',
+        marginBottom: '0.8em',
+        letterSpacing: '-0.01em',
+        fontWeight: 'semibold',
+        lineHeight: '1.5em',
+        scrollMarginTop: 'calc(var(--header-height) + 1.5em)',
+        '& + *': { marginTop: '0' },
+        '& a': { font: 'inherit!' },
+      }}
+      {...props}
+    />
+  )
+}

--- a/apps/website/content/docs/components/clipboard.mdx
+++ b/apps/website/content/docs/components/clipboard.mdx
@@ -9,7 +9,6 @@ description: A component to copy text to the clipboard
 
 ```tsx
 import { Clipboard } from '@snaps-ui/react'
-
 ;<Clipboard.Root>
   <Clipboard.Trigger>
     <Clipboard.CopyText />
@@ -38,6 +37,12 @@ Use the **timeout** prop to change the duration of the copy message.
 You can use the **useClipboard** hook to create a custom clipboard component.
 
 <ExampleTabs name="clipboard-with-store" scope="clipboard" />
+
+### With Status Text
+
+You can use the **Clipboard.Status** to show a copy text.
+
+<ExampleTabs name="clipboard-with-status-text" scope="clipboard" />
 
 ### Root Provider
 

--- a/packages/preset/src/theme/slot-recipe/clipboard.recipe.ts
+++ b/packages/preset/src/theme/slot-recipe/clipboard.recipe.ts
@@ -14,9 +14,10 @@ export const clipboardSlotRecipe = defineSlotRecipe({
       display: 'flex',
       gap: '2',
     },
+    trigger: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '2',
+    },
   },
-
-  variants: {},
-
-  defaultVariants: {},
 })

--- a/packages/snaps-ui/src/components/clipboard/clipboard.tsx
+++ b/packages/snaps-ui/src/components/clipboard/clipboard.tsx
@@ -107,3 +107,15 @@ export const ClipboardContext = ArkClipboard.Context
 
 export interface ClipboardCopyStatusDetails
   extends ArkClipboard.CopyStatusDetails {}
+
+// -------------------- CopyText --------------------
+export const ClipboardStatus = React.forwardRef<
+  HTMLDivElement,
+  ClipboardIndicatorProps
+>(function ClipboardStatus(props, ref) {
+  return (
+    <ClipboardIndicator copied="Copied" ref={ref} {...props}>
+      Copy
+    </ClipboardIndicator>
+  )
+})

--- a/packages/snaps-ui/src/components/clipboard/index.ts
+++ b/packages/snaps-ui/src/components/clipboard/index.ts
@@ -6,6 +6,7 @@ export {
   ClipboardTrigger,
   ClipboardLabel,
   ClipboardInput,
+  ClipboardStatus,
   ClipboardContext,
 } from './clipboard'
 

--- a/packages/snaps-ui/src/components/clipboard/namespace.ts
+++ b/packages/snaps-ui/src/components/clipboard/namespace.ts
@@ -6,6 +6,7 @@ export {
   ClipboardTrigger as Trigger,
   ClipboardLabel as Label,
   ClipboardInput as Input,
+  ClipboardStatus as Status,
   ClipboardContext as Context,
 } from './clipboard'
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes #32  <!-- Github issue # here -->

## 📝 Description

This PR introduces a new **ClipboardStatus** component that provides textual feedback ("Copy" / "Copied") when users interact with the clipboard trigger.
It enhances accessibility and improves the user experience by giving a clear copy state indicator.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

Added **ClipboardStatus** component in the Clipboard module.

Uses ClipboardIndicator internally to handle state transitions.

Displays "Copy" by default and "Copied" when the clipboard state changes.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing snaps ui users. -->

## 📝 Additional Information
