### PR TITLE
feat(preset): allow fidelyPreset to be called without options by usin…

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "dev:content": "velite --watch",
-    "dev:next": "next dev --turbopack",
+    "dev:next": "next dev",
     "build:content": "velite --clean",
-    "build:next": "next build --turbopack",
+    "build:next": "next build",
     "dev": "pnpm run dev:content & pnpm run dev:next",
     "build": "pnpm run build:content && pnpm run build:next",
     "start": "next start",

--- a/packages/preset/src/fidely-preset.ts
+++ b/packages/preset/src/fidely-preset.ts
@@ -13,9 +13,18 @@ import { createRadii } from './utils/createRadii'
 import { recipes } from './theme/recipe'
 import { slotRecipes } from './theme/slot-recipe'
 import * as colors from './colors/index'
+import neutral from './colors/neutral'
 
-export const fidelyPreset = (options: PresetsOptions) => {
-  const { accentColor, rounded, grayColor } = options
+const defaultOptions: Required<PresetsOptions> = {
+  accentColor: neutral,
+  grayColor: neutral,
+  rounded: 'sm',
+}
+
+export const fidelyPreset = (options: PresetsOptions = defaultOptions) => {
+  const mergedOptions = { ...defaultOptions, ...options }
+
+  const { accentColor, rounded, grayColor } = mergedOptions
 
   const normalizeNeutralTokens = (tokens: SemanticTokens['colors']) =>
     JSON.parse(

--- a/packages/preset/src/types.ts
+++ b/packages/preset/src/types.ts
@@ -7,9 +7,9 @@ export interface ColorPalette {
 }
 
 export interface PresetsOptions {
-  accentColor: ColorPalette
-  grayColor: ColorPalette
-  rounded: Radius
+  accentColor?: ColorPalette
+  grayColor?: ColorPalette
+  rounded?: Radius
 }
 
 export type AccentColor = (typeof accentColor)[number]


### PR DESCRIPTION
…g defaults

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

This PR improves the DX of the fidelyPreset by allowing it to be used with or without options.
Previously, the preset required all configuration fields (accentColor, grayColor, rounded) to be provided.

Now the preset supports default values, making all options optional.

> Add a brief description

## ⛳️ Current behavior (updates)

-fidelyPreset(options) required:

 - accentColor

 - grayColor

 - rounded

Calling fidelyPreset() without parameters caused a runtime error due to destructuring undefined.

> Please describe the current behavior that you are modifying

## 🚀 New behavior

All preset configuration options are now optional.

The preset applies built-in defaults when options are not provided.

- Users can now choose:

- fidelyPreset() – use defaults

- fidelyPreset({}) – override nothing

- fidelyPreset({...}) – override only the fields they want

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

No.

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information

- This update improves library ergonomics and avoids unnecessary crashes due to missing option fields.

- It simplifies usage for consumers who want the default Fidely design tokens without additional configuration.

This update is scheduled to go live in the next patch release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined Next.js build process
  * Enhanced design preset system with optional configuration. Default values are now provided for accent color, gray color, and border radius, enabling immediate use without manual setup while supporting full customization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->