### PR TITLE
feat(table): add stickyHeader prop

### DIFF
--- a/packages/preset/src/theme/slot-recipe/table.recipe.ts
+++ b/packages/preset/src/theme/slot-recipe/table.recipe.ts
@@ -83,6 +83,18 @@ export const tableSlotRecipe = defineSlotRecipe({
       },
       false: {},
     },
+    stickyHeader: {
+      true: {
+        header: {
+          '& :where(tr)': {
+            top: '0',
+            position: 'sticky',
+            zIndex: '1',
+          },
+        },
+      },
+      false: {},
+    },
 
     size: {
       sm: {
@@ -110,5 +122,6 @@ export const tableSlotRecipe = defineSlotRecipe({
     size: 'md',
     variant: 'subtle',
     hoverable: false,
+    stickyHeader: false,
   },
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes #44  <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sticky header option for tables—when enabled, table headers remain fixed at the top while scrolling through rows. The feature is disabled by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->