### PR TITLE
fix(component): Bagde asChild, Text, Heading forword as asChild props

### DIFF
--- a/packages/fidely-ui/src/components/badge/badge.tsx
+++ b/packages/fidely-ui/src/components/badge/badge.tsx
@@ -1,23 +1,22 @@
 'use client'
 
 import { forwardRef } from 'react'
-import type { Assign, PolymorphicProps } from '@ark-ui/react'
+import { type PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
 import { styled } from '@fidely-ui/styled-system/jsx'
 import { badge, BadgeVariantProps } from '@fidely-ui/styled-system/recipes'
 import { type HTMLStyledProps } from '@fidely-ui/styled-system/types'
 
 export interface BadgeProps
-  extends Assign<HTMLStyledProps<'span'>, BadgeVariantProps>,
+  extends HTMLStyledProps<'span'>,
+    BadgeVariantProps,
     PolymorphicProps {}
 
 const StyledBadge = styled(ark.span, badge)
 
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
-  function Bagde(props, ref) {
-    const { asChild, ...rest } = props
-
-    return <StyledBadge ref={ref} {...rest} />
+  function Badge(props, ref) {
+    return <StyledBadge ref={ref} {...props} />
   }
 )
 

--- a/packages/fidely-ui/src/components/center/index.tsx
+++ b/packages/fidely-ui/src/components/center/index.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { forwardRef } from 'react'
+import { type PolymorphicProps } from '@ark-ui/react'
+import { ark } from '@ark-ui/react/factory'
 import { HTMLStyledProps, styled } from '@fidely-ui/styled-system/jsx'
 import {
   center,
@@ -11,7 +13,10 @@ import { splitProps } from '../../utils/split-props'
 
 export interface CenterProps
   extends Omit<HTMLStyledProps<'div'>, keyof CenterProperties>,
-    CenterProperties {}
+    CenterProperties,
+    PolymorphicProps {}
+
+const StyledCenter = styled(ark.div)
 
 /**
  * Center component
@@ -24,7 +29,7 @@ export const Center = forwardRef<HTMLDivElement, CenterProps>(
 
     const styles = center.raw(patternProps)
 
-    return <styled.div ref={ref} {...styles} {...restProps} />
+    return <StyledCenter ref={ref} {...styles} {...restProps} />
   }
 )
 

--- a/packages/fidely-ui/src/components/divider/index.tsx
+++ b/packages/fidely-ui/src/components/divider/index.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { forwardRef } from 'react'
+import { type PolymorphicProps } from '@ark-ui/react'
+import { ark } from '@ark-ui/react/factory'
 import { HTMLStyledProps, styled } from '@fidely-ui/styled-system/jsx'
 import {
   divider,
@@ -11,7 +13,10 @@ import { splitProps } from '../../utils/split-props'
 
 export interface DividerProps
   extends Omit<HTMLStyledProps<'div'>, keyof DividerProperties>,
-    DividerProperties {}
+    DividerProperties,
+    PolymorphicProps {}
+
+const StyledDivider = styled(ark.div)
 
 /**
  * Center component
@@ -28,7 +33,7 @@ export const Divider = forwardRef<HTMLDivElement, DividerProps>(
 
     const styles = divider.raw(patternProps)
 
-    return <styled.div ref={ref} {...styles} {...restProps} />
+    return <StyledDivider ref={ref} {...styles} {...restProps} />
   }
 )
 

--- a/packages/fidely-ui/src/components/flex/index.tsx
+++ b/packages/fidely-ui/src/components/flex/index.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { forwardRef } from 'react'
+import { type PolymorphicProps } from '@ark-ui/react'
+import { ark } from '@ark-ui/react/factory'
 import { HTMLStyledProps, styled } from '@fidely-ui/styled-system/jsx'
 import { flex, type FlexProperties } from '@fidely-ui/styled-system/patterns'
 
@@ -8,7 +10,10 @@ import { splitProps } from '../../utils/split-props'
 
 export interface FlexProps
   extends Omit<HTMLStyledProps<'div'>, keyof FlexProperties>,
-    FlexProperties {}
+    FlexProperties,
+    PolymorphicProps {}
+
+const StyledFlex = styled(ark.div)
 
 /**
  * Flex component
@@ -30,7 +35,7 @@ export const Flex = forwardRef<HTMLDivElement, FlexProps>(
 
     const styles = flex.raw(patternProps)
 
-    return <styled.div ref={ref} {...styles} {...restProps} />
+    return <StyledFlex ref={ref} {...styles} {...restProps} />
   }
 )
 

--- a/packages/fidely-ui/src/components/grid/grid.tsx
+++ b/packages/fidely-ui/src/components/grid/grid.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { forwardRef } from 'react'
+import { type PolymorphicProps } from '@ark-ui/react'
+import { ark } from '@ark-ui/react/factory'
 import { HTMLStyledProps, styled } from '@fidely-ui/styled-system/jsx'
 import { grid, type GridProperties } from '@fidely-ui/styled-system/patterns'
 
@@ -8,7 +10,10 @@ import { splitProps } from '../../utils/split-props'
 
 export interface GridProps
   extends Omit<HTMLStyledProps<'div'>, keyof GridProperties>,
-    GridProperties {}
+    GridProperties,
+    PolymorphicProps {}
+
+const StyledGrid = styled(ark.div)
 
 /**
  * Grid component
@@ -27,7 +32,7 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
 
     const styles = grid.raw(patternProps)
 
-    return <styled.div ref={ref} {...styles} {...restProps} />
+    return <StyledGrid ref={ref} {...styles} {...restProps} />
   }
 )
 

--- a/packages/fidely-ui/src/components/grid/gridItem.tsx
+++ b/packages/fidely-ui/src/components/grid/gridItem.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { forwardRef } from 'react'
+import { type PolymorphicProps } from '@ark-ui/react'
+import { ark } from '@ark-ui/react/factory'
 import { HTMLStyledProps, styled } from '@fidely-ui/styled-system/jsx'
 import {
   gridItem,
@@ -11,7 +13,10 @@ import { splitProps } from '../../utils/split-props'
 
 export interface GridItemProps
   extends Omit<HTMLStyledProps<'div'>, keyof GridItemProperties>,
-    GridItemProperties {}
+    GridItemProperties,
+    PolymorphicProps {}
+
+const StyledGridItem = styled(ark.div)
 
 /**
  * GridItem component
@@ -31,7 +36,7 @@ export const GridItem = forwardRef<HTMLDivElement, GridItemProps>(
 
     const styles = gridItem.raw(patternProps)
 
-    return <styled.div ref={ref} {...styles} {...restProps} />
+    return <StyledGridItem ref={ref} {...styles} {...restProps} />
   }
 )
 

--- a/packages/fidely-ui/src/components/heading/index.tsx
+++ b/packages/fidely-ui/src/components/heading/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { forwardRef } from 'react'
-import type { Assign, PolymorphicProps } from '@ark-ui/react'
+import { type PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
 import { styled } from '@fidely-ui/styled-system/jsx'
 import { type HTMLStyledProps } from '@fidely-ui/styled-system/types'
@@ -11,7 +11,8 @@ import {
 } from '@fidely-ui/styled-system/recipes'
 
 export interface HeadingProps
-  extends Assign<HTMLStyledProps<'h2'>, HeadingVariantProps>,
+  extends HTMLStyledProps<'h2'>,
+    HeadingVariantProps,
     PolymorphicProps {}
 
 const StyledHeading = styled(ark.h2, heading)

--- a/packages/fidely-ui/src/components/stack/hstack.tsx
+++ b/packages/fidely-ui/src/components/stack/hstack.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { forwardRef } from 'react'
+import { type PolymorphicProps } from '@ark-ui/react'
+import { ark } from '@ark-ui/react/factory'
 import { HTMLStyledProps, styled } from '@fidely-ui/styled-system/jsx'
 import { hstack, type HstackStyles } from '@fidely-ui/styled-system/patterns'
 
@@ -8,7 +10,10 @@ import { splitProps } from '../../utils/split-props'
 
 export interface HStackProps
   extends Omit<HTMLStyledProps<'div'>, keyof HstackStyles>,
-    HstackStyles {}
+    HstackStyles,
+    PolymorphicProps {}
+
+const StyledHStack = styled(ark.div)
 
 /**
  * HStack component
@@ -21,7 +26,7 @@ export const HStack = forwardRef<HTMLDivElement, HStackProps>(
 
     const styles = hstack.raw(patternProps)
 
-    return <styled.div ref={ref} {...styles} {...restProps} />
+    return <StyledHStack ref={ref} {...styles} {...restProps} />
   }
 )
 

--- a/packages/fidely-ui/src/components/stack/stack.tsx
+++ b/packages/fidely-ui/src/components/stack/stack.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { forwardRef } from 'react'
+import { type PolymorphicProps } from '@ark-ui/react'
+import { ark } from '@ark-ui/react/factory'
 import { HTMLStyledProps, styled } from '@fidely-ui/styled-system/jsx'
 import { stack, type StackProperties } from '@fidely-ui/styled-system/patterns'
 
@@ -8,7 +10,10 @@ import { splitProps } from '../../utils/split-props'
 
 export interface StackProps
   extends Omit<HTMLStyledProps<'div'>, keyof StackProperties>,
-    StackProperties {}
+    StackProperties,
+    PolymorphicProps {}
+
+const StyledStack = styled(ark.div)
 
 /**
  * Stack component
@@ -26,7 +31,7 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
 
     const styles = stack.raw(patternProps)
 
-    return <styled.div ref={ref} {...styles} {...restProps} />
+    return <StyledStack ref={ref} {...styles} {...restProps} />
   }
 )
 

--- a/packages/fidely-ui/src/components/stack/vstack.tsx
+++ b/packages/fidely-ui/src/components/stack/vstack.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { forwardRef } from 'react'
+import { type PolymorphicProps } from '@ark-ui/react'
+import { ark } from '@ark-ui/react/factory'
 import { HTMLStyledProps, styled } from '@fidely-ui/styled-system/jsx'
 import {
   vstack,
@@ -11,7 +13,10 @@ import { splitProps } from '../../utils/split-props'
 
 export interface VStackProps
   extends Omit<HTMLStyledProps<'div'>, keyof VstackProperties>,
-    VstackProperties {}
+    VstackProperties,
+    PolymorphicProps {}
+
+const StyledVStack = styled(ark.div)
 
 /**
  * VStackProps component
@@ -24,7 +29,7 @@ export const VStack = forwardRef<HTMLDivElement, VStackProps>(
 
     const styles = vstack.raw(patternProps)
 
-    return <styled.div ref={ref} {...styles} {...restProps} />
+    return <StyledVStack ref={ref} {...styles} {...restProps} />
   }
 )
 

--- a/packages/fidely-ui/src/components/text/index.tsx
+++ b/packages/fidely-ui/src/components/text/index.tsx
@@ -1,23 +1,22 @@
 'use client'
 
 import { forwardRef } from 'react'
-import { type Assign } from '@ark-ui/react'
-import { ark, type PolymorphicProps } from '@ark-ui/react/factory'
+import { type PolymorphicProps } from '@ark-ui/react'
+import { ark } from '@ark-ui/react/factory'
 import { styled } from '@fidely-ui/styled-system/jsx'
 import { type HTMLStyledProps } from '@fidely-ui/styled-system/types'
 import { text, type TextVariantProps } from '@fidely-ui/styled-system/recipes'
 
 export interface TextProps
-  extends Assign<HTMLStyledProps<'p'>, TextVariantProps>,
+  extends HTMLStyledProps<'p'>,
+    TextVariantProps,
     PolymorphicProps {}
 
 const StyledText = styled(ark.p, text)
 
 export const Text = forwardRef<HTMLParagraphElement, TextProps>(
   function Text(props, ref) {
-    const { className, ...rest } = props
-
-    return <StyledText ref={ref} {...rest} />
+    return <StyledText ref={ref} {...props} />
   }
 )
 

--- a/packages/fidely-ui/src/components/wrap/index.tsx
+++ b/packages/fidely-ui/src/components/wrap/index.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { forwardRef } from 'react'
+import { type PolymorphicProps } from '@ark-ui/react'
+import { ark } from '@ark-ui/react/factory'
 import { HTMLStyledProps, styled } from '@fidely-ui/styled-system/jsx'
 import { wrap, type WrapProperties } from '@fidely-ui/styled-system/patterns'
 
@@ -8,7 +10,10 @@ import { splitProps } from '../../utils/split-props'
 
 export interface WrapProps
   extends Omit<HTMLStyledProps<'div'>, keyof WrapProperties>,
-    WrapProperties {}
+    WrapProperties,
+    PolymorphicProps {}
+
+const StyledWrap = styled(ark.div)
 
 /**
  * Wrap component
@@ -27,7 +32,7 @@ export const Wrap = forwardRef<HTMLDivElement, WrapProps>(
 
     const styles = wrap.raw(patternProps)
 
-    return <styled.div ref={ref} {...styles} {...restProps} />
+    return <StyledWrap ref={ref} {...styles} {...restProps} />
   }
 )
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added polymorphic ("as") prop support to layout and stack components for more flexible rendering.
* **Refactor**
  * Improved Badge, Heading, and Text prop interfaces and rendering for more consistent behavior and metadata.
  * Standardized internal styling wrappers across grid, flex, stack, divider, center, wrap and related components to unify rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->