### PR TITLE
revert(password-input): revert hover state and remove left/right radius

### DIFF
--- a/packages/preset/src/theme/slot-recipe/passwordInput.recipe.ts
+++ b/packages/preset/src/theme/slot-recipe/passwordInput.recipe.ts
@@ -62,9 +62,11 @@ export const passwordInputSlotRecipe = defineSlotRecipe({
       alignItems: 'center',
       color: 'colorPalette.text',
       bg: 'bg.surface',
-      borderRadius: '0',
-      borderTopRightRadius: 's2',
-      borderBottomRightRadius: 's2',
+      borderRadius: 's2',
+
+      _hover: {
+        background: 'colorPalette.alpha4',
+      },
 
       _disabled: {
         color: 'fg.disabled',


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated password input component styling with simplified border radius configuration.
  * Added hover state styling to the password input visibility toggle for improved interactivity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->