### PR TITLE
fix(command-input): prevent crash when shortcut prop is omitted

### DIFF
--- a/CHANNGELOG.md
+++ b/CHANNGELOG.md
@@ -1,5 +1,11 @@
 # @fidely-ui/react
 
+## 2.0.1 - 2026-02-6
+
+### Patch Changes
+
+- fix(command-input): prevent crash and correctly resolve default keyboard shortcuts when the shortcut prop is omitted
+
 ## 2.0.0 - 2026-02-4
 
 ### Major Changes

--- a/packages/fidely-ui/CHANGELOG.md
+++ b/packages/fidely-ui/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @fidely-ui/react
 
+## 2.0.1
+
+### Patch Changes
+
+- fix(command-input): prevent crash and correctly resolve default keyboard shortcuts when the shortcut prop is omitted
+
+- Updated dependencies []:
+  - @fidely-ui/panda-preset@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/fidely-ui/package.json
+++ b/packages/fidely-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fidely-ui/react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "description": "Fidely UI is a modern, beautifully crafted React design system powered by Ark UI and Panda CSS, delivering accessible and themeable components for building exceptional web apps",
   "type": "module",

--- a/packages/fidely-ui/src/components/command-input/command-input.tsx
+++ b/packages/fidely-ui/src/components/command-input/command-input.tsx
@@ -85,9 +85,12 @@ export const CommandInput = React.forwardRef<
 
       {!isMobile && shortcutLabel ? (
         <Flex gap="1" aria-hidden="true">
-          {shortcutLabel.split('+').map((key, i) => (
-            <Kbd key={i}>{key.trim()}</Kbd>
-          ))}
+          {shortcutLabel
+            .split('+')
+            .filter(Boolean)
+            .map((key, i) => (
+              <Kbd key={i}>{key.trim()}</Kbd>
+            ))}
         </Flex>
       ) : null}
     </StyledCommandInput>

--- a/packages/fidely-ui/src/hooks/useCommand.ts
+++ b/packages/fidely-ui/src/hooks/useCommand.ts
@@ -12,19 +12,21 @@ interface UseCommandProps {
 
 export const useCommand = ({ shortcut, onTrigger }: UseCommandProps) => {
   const [isMobile] = React.useState(() =>
-    typeof window !== undefined ? isMobileDevice() : false
+    typeof window !== 'undefined' ? isMobileDevice() : false
   )
 
-  const [resolvedShortcut] = React.useState(() => {
+  const resolvedShortcut = React.useMemo(() => {
     if (isMobile) return null
 
     const isMac =
       typeof navigator !== 'undefined' &&
       /Mac|iPod|iPhone|iPad/.test(navigator.userAgent)
-    const defaultShortcut = isMac ? '⌘ + K' : 'Ctrl + K'
 
-    return parseShortcut(shortcut ?? defaultShortcut)
-  })
+    // If no shortcut is passed, provide a string default BEFORE parsing
+    const shortcutToParse = shortcut || (isMac ? '⌘+K' : 'Ctrl+K')
+
+    return parseShortcut(shortcutToParse)
+  }, [shortcut, isMobile])
 
   const triggerRef = React.useRef(onTrigger)
   React.useEffect(() => {
@@ -73,6 +75,6 @@ export const useCommand = ({ shortcut, onTrigger }: UseCommandProps) => {
 
   return {
     isMobile,
-    shortcutLabel: resolvedShortcut?.label,
+    shortcutLabel: resolvedShortcut?.label ?? '',
   }
 }

--- a/packages/preset/CHANGELOG.md
+++ b/packages/preset/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fidely-ui/panda-preset
 
+## 2.0.1
+
+### Patch Changes
+
+- fix(command-input): prevent crash and correctly resolve default keyboard shortcuts when the shortcut prop is omitted
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/preset/package.json
+++ b/packages/preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fidely-ui/panda-preset",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Fidely UI Panda CSS Preset",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

This PR fixes a runtime error in the `CommandInput` component where calling `.split()` on an undefined shortcutLabel caused the application to crash.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

- Moved shortcut resolution logic from `useState` to `useMemo` for better reliability.

- Added a fallback default shortcut (⌘+K / Ctrl+K) inside the hook.

- Added a safety check in the UI to prevent mapping over undefined labels.

## 💣 Is this a breaking change (Yes/No):
no

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed command-input component crashes when the shortcut property is omitted
* Corrected default keyboard shortcut resolution and rendering for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->