### PR TITLE
fix(select): prevent active border from fading out when dropdown opens

### DIFF
--- a/CHANNGELOG.md
+++ b/CHANNGELOG.md
@@ -1,4 +1,10 @@
-# @fidely-ui/react
+# Changelog
+
+## 2.0.2 - 2026-02-8
+
+### Patch Changes
+
+- Fixed an issue where the Select trigger lost its active border when the dropdown content opened.
 
 ## 2.0.1 - 2026-02-6
 

--- a/packages/fidely-ui/CHANGELOG.md
+++ b/packages/fidely-ui/CHANGELOG.md
@@ -1,4 +1,13 @@
-# @fidely-ui/react
+# Changelog
+
+## 2.0.2
+
+### Patch Changes
+
+- Fixed an issue where the Select trigger lost its active border when the dropdown content opened.
+
+- Updated dependencies []:
+  - @fidely-ui/panda-preset@2.0.2
 
 ## 2.0.1
 

--- a/packages/fidely-ui/package.json
+++ b/packages/fidely-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fidely-ui/react",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": false,
   "description": "Fidely UI is a modern, beautifully crafted React design system powered by Ark UI and Panda CSS, delivering accessible and themeable components for building exceptional web apps",
   "type": "module",

--- a/packages/preset/CHANGELOG.md
+++ b/packages/preset/CHANGELOG.md
@@ -1,4 +1,10 @@
-# @fidely-ui/panda-preset
+# Changelog
+
+## 2.0.2
+
+### Patch Changes
+
+- Fixed an issue where the Select trigger lost its active border when the dropdown content opened.
 
 ## 2.0.1
 

--- a/packages/preset/package.json
+++ b/packages/preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fidely-ui/panda-preset",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Fidely UI Panda CSS Preset",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/preset/src/theme/slot-recipe/select.recipe.ts
+++ b/packages/preset/src/theme/slot-recipe/select.recipe.ts
@@ -40,6 +40,11 @@ export const selectSlotRecipe = defineSlotRecipe({
         color: 'fg.subtle',
       },
 
+      _focusVisible: {
+        outline: '2px solid',
+        outlineColor: 'colorPalette.default',
+      },
+
       '&[data-invalid], &:has([data-invalid])': {
         borderColor: 'fg.error',
         boxShadow: '0 0 0 1px var(--error-color)',
@@ -157,7 +162,7 @@ export const selectSlotRecipe = defineSlotRecipe({
         trigger: {
           borderWidth: '1px',
           borderColor: 'border.default',
-          _focus: {
+          _expanded: {
             borderColor: 'colorPalette.default',
             boxShadow: '0 0 0 1px var(--default-color)',
           },
@@ -165,13 +170,9 @@ export const selectSlotRecipe = defineSlotRecipe({
       },
       subtle: {
         trigger: {
-          borderWidth: '1px',
-          borderColor: 'border.default',
+          borderWidth: 'none',
+          borderColor: 'transparent',
           bg: 'bg.subtle',
-          _focus: {
-            borderColor: 'colorPalette.default',
-            boxShadow: '0 0 0 1px var(--default-color)',
-          },
         },
       },
     },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes #170 <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->
No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Select trigger lost its active border when the dropdown content opened.

* **Chores**
  * Released version 2.0.2 with dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->