### PR TITLE
docs(dialog): add size="full" example and icon stories

### DIFF
--- a/apps/patherns/src/examples/dialog/dialog-fullscreen.tsx
+++ b/apps/patherns/src/examples/dialog/dialog-fullscreen.tsx
@@ -1,0 +1,39 @@
+import { Button, CloseButton, Dialog, Portal, Text } from '@fidely-ui/react'
+
+export const DialogFullscreen = () => {
+  return (
+    <Dialog.Root size="full">
+      <Dialog.Trigger asChild>
+        <Button variant="outline" size="sm">
+          Open Dialog
+        </Button>
+      </Dialog.Trigger>
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.CloseTrigger asChild>
+              <CloseButton size={'sm'} />
+            </Dialog.CloseTrigger>
+            <Dialog.Header>
+              <Dialog.Title>Dialog Title</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Text>
+                Lorem ipsum dolor sit, amet consectetur adipisicing elit. Atque,
+                ullam? Delectus, minus! Incidunt laudantium, cum quae maiores
+                dolore ducimus illo animi, deserunt optio facere dignissimos.
+              </Text>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Dialog.CloseAction asChild>
+                <Button variant={'outline'}>Cancel</Button>
+              </Dialog.CloseAction>
+              <Button>Save</Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  )
+}

--- a/apps/storybook/src/stories/icon.stories.tsx
+++ b/apps/storybook/src/stories/icon.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta } from '@storybook/react-vite'
+import { Box } from '@fidely-ui/react'
+
+export default {
+  title: 'Data Display/Icon',
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <Box p="10">
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta
+
+export { IconBasic as Basics } from 'patherns/examples/icon/icon-basic'
+export { ReactIcon } from 'patherns/examples/icon/react-icon'
+export { IconSvg } from 'patherns/examples/icon/icon-svg'

--- a/apps/website/constant/aside-component-links.ts
+++ b/apps/website/constant/aside-component-links.ts
@@ -27,7 +27,7 @@ export const asideComponentLinks = [
       { name: 'Image', linkUrl: 'image', info: '' },
       { name: 'Table', linkUrl: 'table', info: '' },
       { name: 'Marquee', linkUrl: 'marquee', info: '' },
-      { name: 'Icon', linkUrl: 'icon', info: 'New' },
+      { name: 'Icon', linkUrl: 'icon', info: '' },
     ],
   },
 
@@ -59,7 +59,7 @@ export const asideComponentLinks = [
       { name: 'Field', linkUrl: 'field', info: '' },
       { name: 'Input', linkUrl: 'input', info: '' },
       { name: 'Textarea', linkUrl: 'textarea', info: '' },
-      { name: 'Command Input', linkUrl: 'command-input', info: 'Updated' },
+      { name: 'Command Input', linkUrl: 'command-input', info: '' },
       { name: 'Combobox', linkUrl: 'combobox', info: '' },
       { name: 'Input Group', linkUrl: 'input-group', info: '' },
       { name: 'Pin Input', linkUrl: 'pin-input', info: '' },
@@ -77,7 +77,7 @@ export const asideComponentLinks = [
       { name: 'Dialog', linkUrl: 'dialog', info: '' },
       { name: 'Hover Card', linkUrl: 'hover-card', info: '' },
       { name: 'Menu', linkUrl: 'menu', info: '' },
-      { name: 'Popover', linkUrl: 'popover', info: 'New' },
+      { name: 'Popover', linkUrl: 'popover', info: '' },
     ],
   },
 
@@ -95,7 +95,7 @@ export const asideUtilLinks = [
     section: 'Utilities',
     items: [
       { name: 'Client Only', linkUrl: 'client-only', info: '' },
-      { name: 'Locale Provider', linkUrl: 'locale-provider', info: 'New' },
+      { name: 'Locale Provider', linkUrl: 'locale-provider', info: '' },
       { name: 'Portal', linkUrl: 'portal', info: '' },
       { name: 'Download Trigger', linkUrl: 'download-trigger', info: '' },
       { name: 'Formats', linkUrl: 'formats', info: '' },
@@ -108,7 +108,7 @@ export const asideStylingLinks = [
     section: 'Styling',
     items: [
       { name: 'Dark Mode', linkUrl: 'dark-mode', info: '' },
-      { name: 'Fidely Factory', linkUrl: 'fidely-factory', info: 'Updated' },
+      { name: 'Fidely Factory', linkUrl: 'fidely-factory', info: '' },
       { name: 'Css Variables', linkUrl: 'css-variables', info: '' },
       { name: 'Responsive Design', linkUrl: 'responsive-design', info: '' },
       // { name: 'Color Opacity Modifier', linkUrl: 'color-opacity-modifier', info: '' },

--- a/apps/website/content/docs/components/dialog.mdx
+++ b/apps/website/content/docs/components/dialog.mdx
@@ -40,6 +40,12 @@ Use the **size** prop to change the size of the dialog component.
 
 <ExampleTabs name="dialog-sizes" scope="dialog" />
 
+### Fullscreen
+
+Use the **`size="full"`** prop to make the dialog fill the entire viewport.
+
+<ExampleTabs name="dialog-fullscreen" scope="dialog" />
+
 ### Controlled
 
 Use the **open** and **onOpenChange** prop to control the visibility of the dialog component.
@@ -87,7 +93,7 @@ Use the **initialFocusEl** prop to set the initial focus of the dialog component
 | `modal`                  | `boolean`                                                                                                                                 | `true`     | Whether to prevent pointer interaction outside the element and hide all content below it.                               |
 | `preventScroll`          | `boolean`                                                                                                                                 | `true`     | Whether to prevent scrolling behind the dialog when it's opened                                                         |
 | `role`                   | `"dialog" \| "alertdialog"`                                                                                                               | `"dialog"` | The dialog's role.                                                                                                      |
-| `size`                   | ` "xs" \| "sm" \| "md" \| "lg"`                                                                                                           | `"md"`     | Controls the size of the switch.                                                                                        |
+| `size`                   | ` "xs" \| "sm" \| "md" \| "lg" \| "full"`                                                                                                 | `"md"`     | Controls the size of the switch.                                                                                        |
 | `skipAnimationOnMount`   | `boolean                                                                                                                                  | `"false"`  | Whether to allow the initial presence animation.                                                                        |
 | `unmountOnExit`          | `boolean`                                                                                                                                 | `false`    | Whether to unmount on exit.                                                                                             |
 | `trapFocus`              | `boolean`                                                                                                                                 | `true`     | Whether to trap focus inside the dialog when it's opened.                                                               |


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fullscreen dialog component example with open/close functionality.
  * Added Icon component showcase stories to Storybook with multiple variants.

* **Documentation**
  * Updated dialog component documentation to include fullscreen size option.
  * Refreshed component status labels across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->