### PR TITLE
style(website): remove animations from landing page

### DIFF
--- a/apps/website/components/hero/hero-card-playlist.tsx
+++ b/apps/website/components/hero/hero-card-playlist.tsx
@@ -15,12 +15,7 @@ import {
 
 export const HeroCardPlaylist = () => {
   return (
-    <Card.Root
-      width="100%"
-      maxWidth="320px"
-      height="min-content"
-      animationStyle="float"
-    >
+    <Card.Root width="100%" maxWidth="320px" height="min-content">
       <Card.Body>
         <Flex gap="1" align="center">
           <Box width="30%">

--- a/apps/website/components/hero/hero-card.tsx
+++ b/apps/website/components/hero/hero-card.tsx
@@ -9,12 +9,7 @@ import { Text } from '@fidely-ui/react/text'
 
 export const HeroCard = () => {
   return (
-    <Card.Root
-      width="100%"
-      maxWidth="320px"
-      height="min-content"
-      animationStyle="float"
-    >
+    <Card.Root width="100%" maxWidth="320px" height="min-content">
       <Card.Body>
         <Stack gap="3">
           <Flex justify="space-between" width="full">

--- a/apps/website/components/hero/hero-highlight-card.tsx
+++ b/apps/website/components/hero/hero-highlight-card.tsx
@@ -8,12 +8,7 @@ import { Text } from '@fidely-ui/react/text'
 
 export const HeroHighlightCard = () => {
   return (
-    <Card.Root
-      maxWidth="420px"
-      boxShadow="xl"
-      animationStyle="floatSlow"
-      animationDelay="1.4s"
-    >
+    <Card.Root maxWidth="420px" boxShadow="xl">
       <Card.Body>
         <Stack gap="4">
           <Box px="3" py="1">

--- a/apps/website/components/hero/hero-menu.tsx
+++ b/apps/website/components/hero/hero-menu.tsx
@@ -9,7 +9,7 @@ import { MdKeyboardCommandKey } from 'react-icons/md'
 
 export const HeroMenu = () => {
   return (
-    <Stack animationStyle="float" animationDelay="1.8s">
+    <Stack>
       <Text>Menu</Text>
 
       <Menu.Root>

--- a/apps/website/components/hero/hero-spinner.tsx
+++ b/apps/website/components/hero/hero-spinner.tsx
@@ -4,13 +4,7 @@ import { Spinner } from '@fidely-ui/react/spinner'
 
 export const HeroSpinner = () => {
   return (
-    <Card.Root
-      width="100%"
-      maxWidth="130px"
-      height="min-content"
-      animationStyle="float"
-      animationDelay="1.2s"
-    >
+    <Card.Root width="100%" maxWidth="130px" height="min-content">
       <Card.Body height="100px">
         <Center height="200px">
           <Spinner size="xl" colorPalette="orange" />

--- a/apps/website/components/hero/hero-switch.tsx
+++ b/apps/website/components/hero/hero-switch.tsx
@@ -13,8 +13,6 @@ export const HeroSwitch = () => {
       defaultChecked
       onCheckedChange={toggleTheme}
       size="lg"
-      animationStyle="float"
-      animationDelay="0.6s"
     >
       <Switch.HiddenInput />
       <Switch.Control>

--- a/apps/website/components/hero/hero-tabs.tsx
+++ b/apps/website/components/hero/hero-tabs.tsx
@@ -3,7 +3,7 @@ import { Tabs } from '@fidely-ui/react/tabs'
 
 export const HeroTabs = () => {
   return (
-    <Stack animationStyle="float" animationDelay="2.4s">
+    <Stack>
       <Tabs.Root
         defaultValue="fidely-ui"
         variant="outline"

--- a/apps/website/panda.config.ts
+++ b/apps/website/panda.config.ts
@@ -29,29 +29,7 @@ export default defineConfig({
   },
 
   theme: {
-    extend: {
-      keyframes: {
-        float: {
-          '0%': { transform: 'translateY(0)' },
-          '50%': { transform: 'translateY(-12px)' },
-          '100%': { transform: 'translateY(0)' },
-        },
-      },
-
-      animationStyles: {
-        float: {
-          value: {
-            animation: 'float 6s ease-in-out infinite',
-          },
-        },
-
-        floatSlow: {
-          value: {
-            animation: 'float 9s ease-in-out infinite',
-          },
-        },
-      },
-    },
+    extend: {},
   },
 
   globalCss: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed floating animation effects from hero section components (cards, menu, spinner, switches, tabs). Animation delays and custom keyframe configurations have been eliminated, resulting in a simplified, static visual presentation without transition effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->