### PR TITLE
revert(slots): use default UnstyledProps from HTMLStyledProps

### DIFF
--- a/packages/fidely-ui/src/components/accordion/accordion.tsx
+++ b/packages/fidely-ui/src/components/accordion/accordion.tsx
@@ -3,20 +3,17 @@
 import type { Assign } from '@ark-ui/react'
 import { Accordion as ArkAccordion } from '@ark-ui/react/accordion'
 import { accordion, type AccordionVariantProps } from 'styled-system/recipes'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 
 import { makeStyleContext } from '../../system/make-style-context'
 
 const { withSlotProvider, withSlotContext } = makeStyleContext(accordion)
 
 // -------------------- RootProvider --------------------
-export interface AccordionRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkAccordion.RootProviderBaseProps>,
-      AccordionVariantProps
-    >,
-    UnstyledProps {}
+export interface AccordionRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkAccordion.RootProviderBaseProps>,
+  AccordionVariantProps
+> {}
 
 export const AccordionRootProvider = withSlotProvider<
   HTMLDivElement,
@@ -24,13 +21,10 @@ export const AccordionRootProvider = withSlotProvider<
 >(ArkAccordion.RootProvider, 'root')
 
 // -------------------- Root --------------------
-export interface AccordionRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkAccordion.RootBaseProps>,
-      AccordionVariantProps
-    >,
-    UnstyledProps {}
+export interface AccordionRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkAccordion.RootBaseProps>,
+  AccordionVariantProps
+> {}
 
 export const AccordionRoot = withSlotProvider<
   HTMLDivElement,
@@ -38,10 +32,10 @@ export const AccordionRoot = withSlotProvider<
 >(ArkAccordion.Root, 'root')
 
 // -------------------- Item --------------------
-export interface AccordionItemProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkAccordion.ItemBaseProps>,
-    UnstyledProps {}
+export interface AccordionItemProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkAccordion.ItemBaseProps
+> {}
 
 export const AccordionItem = withSlotContext<
   HTMLDivElement,
@@ -49,10 +43,10 @@ export const AccordionItem = withSlotContext<
 >(ArkAccordion.Item, 'item')
 
 // -------------------- Content --------------------
-export interface AccordionItemContentProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkAccordion.ItemContentBaseProps>,
-    UnstyledProps {}
+export interface AccordionItemContentProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkAccordion.ItemContentBaseProps
+> {}
 
 export const AccordionItemContent = withSlotContext<
   HTMLDivElement,
@@ -60,10 +54,10 @@ export const AccordionItemContent = withSlotContext<
 >(ArkAccordion.ItemContent, 'itemContent')
 
 // -------------------- Trigger --------------------
-export interface AccordionItemTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkAccordion.ItemTriggerBaseProps>,
-    UnstyledProps {}
+export interface AccordionItemTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkAccordion.ItemTriggerBaseProps
+> {}
 
 export const AccordionItemTrigger = withSlotContext<
   HTMLButtonElement,
@@ -71,10 +65,10 @@ export const AccordionItemTrigger = withSlotContext<
 >(ArkAccordion.ItemTrigger, 'itemTrigger')
 
 // -------------------- Indicator --------------------
-export interface AccordionItemIndicatorProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkAccordion.ItemIndicatorBaseProps>,
-    UnstyledProps {}
+export interface AccordionItemIndicatorProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkAccordion.ItemIndicatorBaseProps
+> {}
 
 export const AccordionItemIndicator = withSlotContext<
   HTMLDivElement,

--- a/packages/fidely-ui/src/components/avatar/avatar.tsx
+++ b/packages/fidely-ui/src/components/avatar/avatar.tsx
@@ -5,7 +5,7 @@ import { ark } from '@ark-ui/react/factory'
 import type { Assign, HTMLArkProps } from '@ark-ui/react'
 import { Avatar as ArkAvatar } from '@ark-ui/react/avatar'
 import { avatar, type AvatarVariantProps } from 'styled-system/recipes'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { styled } from 'styled-system/jsx'
 
 import { makeStyleContext } from '../../system/make-style-context'
@@ -14,13 +14,10 @@ import { getInitials } from '../../utils/get-initial'
 const { withSlotProvider, withSlotContext } = makeStyleContext(avatar)
 
 // -------------------- RootProvider --------------------
-export interface AvatarRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkAvatar.RootProviderBaseProps>,
-      AvatarVariantProps
-    >,
-    UnstyledProps {}
+export interface AvatarRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkAvatar.RootProviderBaseProps>,
+  AvatarVariantProps
+> {}
 
 export const AvatarRootProvider = withSlotProvider<
   HTMLDivElement,
@@ -28,13 +25,10 @@ export const AvatarRootProvider = withSlotProvider<
 >(ArkAvatar.RootProvider, 'root')
 
 // -------------------- Root --------------------
-export interface AvatarRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkAvatar.RootBaseProps>,
-      AvatarVariantProps
-    >,
-    UnstyledProps {}
+export interface AvatarRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkAvatar.RootBaseProps>,
+  AvatarVariantProps
+> {}
 
 export const AvatarRoot = withSlotProvider<HTMLDivElement, AvatarRootProps>(
   ArkAvatar.Root,
@@ -42,10 +36,10 @@ export const AvatarRoot = withSlotProvider<HTMLDivElement, AvatarRootProps>(
 )
 
 // -------------------- Fallback --------------------
-export interface AvatarFallbackProps
-  extends
-    Assign<HTMLStyledProps<'span'>, ArkAvatar.FallbackBaseProps>,
-    UnstyledProps {
+export interface AvatarFallbackProps extends Assign<
+  HTMLStyledProps<'span'>,
+  ArkAvatar.FallbackBaseProps
+> {
   /**
    * The name to derive the initials from the avatar.
    */
@@ -71,10 +65,10 @@ export const AvatarFallback = forwardRef<HTMLDivElement, AvatarFallbackProps>(
   }
 )
 // -------------------- Image --------------------
-export interface AvatarImageProps
-  extends
-    Assign<HTMLStyledProps<'img'>, ArkAvatar.ImageBaseProps>,
-    UnstyledProps {}
+export interface AvatarImageProps extends Assign<
+  HTMLStyledProps<'img'>,
+  ArkAvatar.ImageBaseProps
+> {}
 
 export const AvatarImage = withSlotContext<HTMLImageElement, AvatarImageProps>(
   ArkAvatar.Image,

--- a/packages/fidely-ui/src/components/card/card.tsx
+++ b/packages/fidely-ui/src/components/card/card.tsx
@@ -2,7 +2,7 @@
 
 import type { Assign, HTMLArkProps, PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { card, type CardVariantProps } from 'styled-system/recipes'
 
 import { makeStyleContext } from '../../system/make-style-context'
@@ -13,10 +13,10 @@ import { makeStyleContext } from '../../system/make-style-context'
 const { withSlotProvider, withSlotContext } = makeStyleContext(card)
 
 // -------------------- Root --------------------
-export interface CardRootProps
-  extends
-    Assign<Assign<HTMLStyledProps<'div'>, PolymorphicProps>, CardVariantProps>,
-    UnstyledProps {}
+export interface CardRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, PolymorphicProps>,
+  CardVariantProps
+> {}
 
 export const CardRoot = withSlotProvider<HTMLDivElement, CardRootProps>(
   ark.div,
@@ -24,8 +24,10 @@ export const CardRoot = withSlotProvider<HTMLDivElement, CardRootProps>(
 )
 
 // -------------------- Body --------------------
-export interface CardBodyProps
-  extends Assign<HTMLStyledProps<'div'>, PolymorphicProps>, UnstyledProps {}
+export interface CardBodyProps extends Assign<
+  HTMLStyledProps<'div'>,
+  PolymorphicProps
+> {}
 
 export const CardBody = withSlotContext<HTMLDivElement, CardBodyProps>(
   ark.div,
@@ -33,8 +35,10 @@ export const CardBody = withSlotContext<HTMLDivElement, CardBodyProps>(
 )
 
 // -------------------- Header --------------------
-export interface CardHeaderProps
-  extends Assign<HTMLStyledProps<'div'>, PolymorphicProps>, UnstyledProps {}
+export interface CardHeaderProps extends Assign<
+  HTMLStyledProps<'div'>,
+  PolymorphicProps
+> {}
 
 export const CardHeader = withSlotContext<HTMLDivElement, CardHeaderProps>(
   ark.div,
@@ -42,8 +46,10 @@ export const CardHeader = withSlotContext<HTMLDivElement, CardHeaderProps>(
 )
 
 // -------------------- Title --------------------
-export interface CardTitleProps
-  extends Assign<HTMLStyledProps<'h4'>, HTMLArkProps<'h4'>>, UnstyledProps {}
+export interface CardTitleProps extends Assign<
+  HTMLStyledProps<'h4'>,
+  HTMLArkProps<'h4'>
+> {}
 
 export const CardTitle = withSlotContext<HTMLHeadingElement, CardTitleProps>(
   ark.h4,
@@ -51,8 +57,10 @@ export const CardTitle = withSlotContext<HTMLHeadingElement, CardTitleProps>(
 )
 
 // -------------------- Description --------------------
-export interface CardDescriptionProps
-  extends Assign<HTMLStyledProps<'div'>, PolymorphicProps>, UnstyledProps {}
+export interface CardDescriptionProps extends Assign<
+  HTMLStyledProps<'div'>,
+  PolymorphicProps
+> {}
 
 export const CardDescription = withSlotContext<
   HTMLDivElement,
@@ -60,8 +68,10 @@ export const CardDescription = withSlotContext<
 >(ark.div, 'description')
 
 // -------------------- Footer --------------------
-export interface CardFooterProps
-  extends Assign<HTMLStyledProps<'div'>, PolymorphicProps>, UnstyledProps {}
+export interface CardFooterProps extends Assign<
+  HTMLStyledProps<'div'>,
+  PolymorphicProps
+> {}
 
 export const CardFooter = withSlotContext<HTMLDivElement, CardFooterProps>(
   ark.div,

--- a/packages/fidely-ui/src/components/checkbox/checkbox.tsx
+++ b/packages/fidely-ui/src/components/checkbox/checkbox.tsx
@@ -2,23 +2,19 @@
 
 import type { Assign } from '@ark-ui/react'
 import { Checkbox as ArkCheckbox } from '@ark-ui/react/checkbox'
-import { HTMLStyledProps } from 'styled-system/jsx'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { checkbox, CheckboxVariantProps } from 'styled-system/recipes'
 
 import { makeStyleContext } from '../../system/make-style-context'
 import { FiCheck } from '../../icons/FiCheck'
-import { UnstyledProps } from 'styled-system/types'
 
 const { withSlotProvider, withSlotContext } = makeStyleContext(checkbox)
 
 // -------------------- Root Provider --------------------
-export interface CheckboxRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkCheckbox.RootProviderBaseProps>,
-      CheckboxVariantProps
-    >,
-    UnstyledProps {}
+export interface CheckboxRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkCheckbox.RootProviderBaseProps>,
+  CheckboxVariantProps
+> {}
 
 export const CheckboxRootProvider = withSlotProvider<
   HTMLDivElement,
@@ -26,13 +22,10 @@ export const CheckboxRootProvider = withSlotProvider<
 >(ArkCheckbox.RootProvider, 'root')
 
 // -------------------- Root --------------------
-export interface CheckboxRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkCheckbox.RootBaseProps>,
-      CheckboxVariantProps
-    >,
-    UnstyledProps {}
+export interface CheckboxRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkCheckbox.RootBaseProps>,
+  CheckboxVariantProps
+> {}
 
 export const CheckboxRoot = withSlotProvider<HTMLDivElement, CheckboxRootProps>(
   ArkCheckbox.Root,
@@ -40,10 +33,10 @@ export const CheckboxRoot = withSlotProvider<HTMLDivElement, CheckboxRootProps>(
 )
 
 // -------------------- Group --------------------
-export interface CheckboxGroupProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCheckbox.GroupBaseProps>,
-    UnstyledProps {}
+export interface CheckboxGroupProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCheckbox.GroupBaseProps
+> {}
 
 export const CheckboxGroup = withSlotContext<
   HTMLDivElement,
@@ -51,10 +44,10 @@ export const CheckboxGroup = withSlotContext<
 >(ArkCheckbox.Group, 'group')
 
 // -------------------- Control --------------------
-export interface CheckboxControlProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCheckbox.ControlBaseProps>,
-    UnstyledProps {}
+export interface CheckboxControlProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCheckbox.ControlBaseProps
+> {}
 
 export const CheckboxControl = withSlotContext<
   HTMLDivElement,
@@ -62,10 +55,10 @@ export const CheckboxControl = withSlotContext<
 >(ArkCheckbox.Control, 'control')
 
 // -------------------- Label --------------------
-export interface CheckboxLabelProps
-  extends
-    Assign<HTMLStyledProps<'span'>, ArkCheckbox.LabelBaseProps>,
-    UnstyledProps {}
+export interface CheckboxLabelProps extends Assign<
+  HTMLStyledProps<'span'>,
+  ArkCheckbox.LabelBaseProps
+> {}
 
 export const CheckboxLabel = withSlotContext<
   HTMLSpanElement,
@@ -73,10 +66,10 @@ export const CheckboxLabel = withSlotContext<
 >(ArkCheckbox.Label, 'label')
 
 // -------------------- Indicator --------------------
-export interface CheckboxIndicatorProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCheckbox.IndicatorBaseProps>,
-    UnstyledProps {
+export interface CheckboxIndicatorProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCheckbox.IndicatorBaseProps
+> {
   idleIcon?: React.ReactNode
 }
 

--- a/packages/fidely-ui/src/components/clipboard/clipboard.tsx
+++ b/packages/fidely-ui/src/components/clipboard/clipboard.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import type { Assign } from '@ark-ui/react'
 import { Clipboard as ArkClipboard } from '@ark-ui/react/clipboard'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { clipboard, type ClipboardVariantProps } from 'styled-system/recipes'
 
 import { FiCheck } from '../../icons/FiCheck'
@@ -13,13 +13,10 @@ import { makeStyleContext } from '../../system/make-style-context'
 const { withSlotProvider, withSlotContext } = makeStyleContext(clipboard)
 
 // -------------------- RootProvider --------------------
-export interface ClipboardRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkClipboard.RootProviderBaseProps>,
-      ClipboardVariantProps
-    >,
-    UnstyledProps {}
+export interface ClipboardRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkClipboard.RootProviderBaseProps>,
+  ClipboardVariantProps
+> {}
 
 export const ClipboardRootProvider = withSlotProvider<
   HTMLDivElement,
@@ -27,13 +24,10 @@ export const ClipboardRootProvider = withSlotProvider<
 >(ArkClipboard.RootProvider, 'root')
 
 // -------------------- Root --------------------
-export interface ClipboardRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkClipboard.RootBaseProps>,
-      ClipboardVariantProps
-    >,
-    UnstyledProps {}
+export interface ClipboardRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkClipboard.RootBaseProps>,
+  ClipboardVariantProps
+> {}
 
 export const ClipboardRoot = withSlotProvider<
   HTMLDivElement,
@@ -41,10 +35,10 @@ export const ClipboardRoot = withSlotProvider<
 >(ArkClipboard.Root, 'root')
 
 // -------------------- Control --------------------
-export interface ClipboardControlProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkClipboard.ControlBaseProps>,
-    UnstyledProps {}
+export interface ClipboardControlProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkClipboard.ControlBaseProps
+> {}
 
 export const ClipboardControl = withSlotContext<
   HTMLDivElement,
@@ -52,10 +46,10 @@ export const ClipboardControl = withSlotContext<
 >(ArkClipboard.Control, 'control')
 
 // -------------------- Trigger --------------------
-export interface ClipboardTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkClipboard.TriggerBaseProps>,
-    UnstyledProps {}
+export interface ClipboardTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkClipboard.TriggerBaseProps
+> {}
 
 export const ClipboardTrigger = withSlotContext<
   HTMLDivElement,
@@ -63,10 +57,10 @@ export const ClipboardTrigger = withSlotContext<
 >(ArkClipboard.Trigger, 'trigger')
 
 // -------------------- Indicator --------------------
-export interface ClipboardIndicatorProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkClipboard.IndicatorBaseProps>,
-    UnstyledProps {
+export interface ClipboardIndicatorProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkClipboard.IndicatorBaseProps
+> {
   copiedIcon?: React.ReactNode
   idleIcon?: React.ReactNode
 }
@@ -90,10 +84,10 @@ export const ClipboardIndicator = withSlotContext<
 }, 'indicator')
 
 // -------------------- Input --------------------
-export interface ClipboardInputProps
-  extends
-    Assign<HTMLStyledProps<'input'>, ArkClipboard.InputBaseProps>,
-    UnstyledProps {}
+export interface ClipboardInputProps extends Assign<
+  HTMLStyledProps<'input'>,
+  ArkClipboard.InputBaseProps
+> {}
 
 export const ClipboardInput = withSlotContext<
   HTMLDivElement,
@@ -101,10 +95,10 @@ export const ClipboardInput = withSlotContext<
 >(ArkClipboard.Input, 'input')
 
 // -------------------- Label --------------------
-export interface ClipboardLabelProps
-  extends
-    Assign<HTMLStyledProps<'label'>, ArkClipboard.LabelBaseProps>,
-    UnstyledProps {}
+export interface ClipboardLabelProps extends Assign<
+  HTMLStyledProps<'label'>,
+  ArkClipboard.LabelBaseProps
+> {}
 
 export const ClipboardLabel = withSlotContext<
   HTMLDivElement,

--- a/packages/fidely-ui/src/components/combobox/combobox.tsx
+++ b/packages/fidely-ui/src/components/combobox/combobox.tsx
@@ -3,7 +3,7 @@
 import type { Assign, CollectionItem } from '@ark-ui/react'
 import { Combobox as ArkCombobox } from '@ark-ui/react/combobox'
 import { combobox, type ComboboxVariantProps } from 'styled-system/recipes'
-import { UnstyledProps, type HTMLStyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 
 import { makeStyleContext } from '../../system/make-style-context'
 import { FiClose } from '../../icons/FiClose'
@@ -12,13 +12,12 @@ import { FiCaretDownIcon } from '../../icons/FiCaretDownIcon'
 const { withSlotProvider, withSlotContext } = makeStyleContext(combobox)
 
 // -------------------- RootProvider --------------------
-export interface ComboboxRootProviderProps<T extends CollectionItem = any>
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkCombobox.RootProviderBaseProps<T>>,
-      ComboboxVariantProps
-    >,
-    UnstyledProps {}
+export interface ComboboxRootProviderProps<
+  T extends CollectionItem = any,
+> extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkCombobox.RootProviderBaseProps<T>>,
+  ComboboxVariantProps
+> {}
 
 export const ComboboxRootProvider = withSlotProvider<
   HTMLDivElement,
@@ -26,13 +25,12 @@ export const ComboboxRootProvider = withSlotProvider<
 >(ArkCombobox.RootProvider, 'root')
 
 // -------------------- Root --------------------
-export interface ComboboxRootProps<T extends CollectionItem = any>
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkCombobox.RootBaseProps<T>>,
-      ComboboxVariantProps
-    >,
-    UnstyledProps {}
+export interface ComboboxRootProps<
+  T extends CollectionItem = any,
+> extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkCombobox.RootBaseProps<T>>,
+  ComboboxVariantProps
+> {}
 
 export const ComboboxRoot = withSlotProvider<HTMLDivElement, ComboboxRootProps>(
   ArkCombobox.Root,
@@ -40,10 +38,10 @@ export const ComboboxRoot = withSlotProvider<HTMLDivElement, ComboboxRootProps>(
 )
 
 // -------------------- Label --------------------
-export interface ComboboxLabelProps
-  extends
-    Assign<HTMLStyledProps<'label'>, ArkCombobox.LabelBaseProps>,
-    UnstyledProps {}
+export interface ComboboxLabelProps extends Assign<
+  HTMLStyledProps<'label'>,
+  ArkCombobox.LabelBaseProps
+> {}
 
 export const ComboboxLabel = withSlotContext<
   HTMLLabelElement,
@@ -51,10 +49,10 @@ export const ComboboxLabel = withSlotContext<
 >(ArkCombobox.Label, 'label')
 
 // -------------------- Control --------------------
-export interface ComboboxControlProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCombobox.ControlBaseProps>,
-    UnstyledProps {}
+export interface ComboboxControlProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCombobox.ControlBaseProps
+> {}
 
 export const ComboboxControl = withSlotContext<
   HTMLDivElement,
@@ -62,10 +60,10 @@ export const ComboboxControl = withSlotContext<
 >(ArkCombobox.Control, 'control')
 
 // -------------------- Input --------------------
-export interface ComboboxInputProps
-  extends
-    Assign<HTMLStyledProps<'input'>, ArkCombobox.InputBaseProps>,
-    UnstyledProps {}
+export interface ComboboxInputProps extends Assign<
+  HTMLStyledProps<'input'>,
+  ArkCombobox.InputBaseProps
+> {}
 
 export const ComboboxInput = withSlotContext<
   HTMLInputElement,
@@ -73,10 +71,10 @@ export const ComboboxInput = withSlotContext<
 >(ArkCombobox.Input, 'input')
 
 // -------------------- Trigger --------------------
-export interface ComboboxTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkCombobox.TriggerBaseProps>,
-    UnstyledProps {
+export interface ComboboxTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkCombobox.TriggerBaseProps
+> {
   idleIcon?: React.ReactNode
 }
 
@@ -92,10 +90,10 @@ export const ComboboxTrigger = withSlotContext<
 }, 'trigger')
 
 // -------------------- ClearTrigger --------------------
-export interface ComboboxClearTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkCombobox.ClearTriggerBaseProps>,
-    UnstyledProps {
+export interface ComboboxClearTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkCombobox.ClearTriggerBaseProps
+> {
   idleIcon?: React.ReactNode
 }
 
@@ -113,10 +111,10 @@ export const ComboboxClearTrigger = withSlotContext<
 }, 'clearTrigger')
 
 // -------------------- Positioner --------------------
-export interface ComboboxPositionerProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCombobox.PositionerBaseProps>,
-    UnstyledProps {}
+export interface ComboboxPositionerProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCombobox.PositionerBaseProps
+> {}
 
 export const ComboboxPositioner = withSlotContext<
   HTMLDivElement,
@@ -124,10 +122,10 @@ export const ComboboxPositioner = withSlotContext<
 >(ArkCombobox.Positioner, 'positioner')
 
 // -------------------- Content --------------------
-export interface ComboboxContentProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCombobox.ContentBaseProps>,
-    UnstyledProps {}
+export interface ComboboxContentProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCombobox.ContentBaseProps
+> {}
 
 export const ComboboxContent = withSlotContext<
   HTMLDivElement,
@@ -135,10 +133,10 @@ export const ComboboxContent = withSlotContext<
 >(ArkCombobox.Content, 'content')
 
 // -------------------- ItemGroup --------------------
-export interface ComboboxItemGroupProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCombobox.ItemGroupBaseProps>,
-    UnstyledProps {}
+export interface ComboboxItemGroupProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCombobox.ItemGroupBaseProps
+> {}
 
 export const ComboboxItemGroup = withSlotContext<
   HTMLDivElement,
@@ -146,10 +144,10 @@ export const ComboboxItemGroup = withSlotContext<
 >(ArkCombobox.ItemGroup, 'itemGroup')
 
 // -------------------- ItemGroupLabel --------------------
-export interface ComboboxItemGroupLabelProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCombobox.ItemGroupLabelBaseProps>,
-    UnstyledProps {}
+export interface ComboboxItemGroupLabelProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCombobox.ItemGroupLabelBaseProps
+> {}
 
 export const ComboboxItemGroupLabel = withSlotContext<
   HTMLDivElement,
@@ -157,10 +155,10 @@ export const ComboboxItemGroupLabel = withSlotContext<
 >(ArkCombobox.ItemGroupLabel, 'itemGroupLabel')
 
 // -------------------- Item --------------------
-export interface ComboboxItemProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCombobox.ItemBaseProps>,
-    UnstyledProps {}
+export interface ComboboxItemProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCombobox.ItemBaseProps
+> {}
 
 export const ComboboxItem = withSlotContext<HTMLDivElement, ComboboxItemProps>(
   ArkCombobox.Item,
@@ -168,10 +166,10 @@ export const ComboboxItem = withSlotContext<HTMLDivElement, ComboboxItemProps>(
 )
 
 // -------------------- ItemText --------------------
-export interface ComboboxItemTextProps
-  extends
-    Assign<HTMLStyledProps<'span'>, ArkCombobox.ItemTextBaseProps>,
-    UnstyledProps {}
+export interface ComboboxItemTextProps extends Assign<
+  HTMLStyledProps<'span'>,
+  ArkCombobox.ItemTextBaseProps
+> {}
 
 export const ComboboxItemText = withSlotContext<
   HTMLSpanElement,
@@ -179,10 +177,10 @@ export const ComboboxItemText = withSlotContext<
 >(ArkCombobox.ItemText, 'itemText')
 
 // -------------------- ItemIndicator --------------------
-export interface ComboboxItemIndicatorProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCombobox.ItemIndicatorBaseProps>,
-    UnstyledProps {}
+export interface ComboboxItemIndicatorProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCombobox.ItemIndicatorBaseProps
+> {}
 
 export const ComboboxItemIndicator = withSlotContext<
   HTMLDivElement,
@@ -190,8 +188,7 @@ export const ComboboxItemIndicator = withSlotContext<
 >(ArkCombobox.ItemIndicator, 'itemIndicator')
 
 // -------------------- IndicatorGroup --------------------
-export interface ComboboxIndicatorGroupProps
-  extends HTMLStyledProps<'div'>, UnstyledProps {}
+export interface ComboboxIndicatorGroupProps extends HTMLStyledProps<'div'> {}
 
 export const ComboboxIndicatorGroup = withSlotContext<
   HTMLDivElement,
@@ -199,10 +196,10 @@ export const ComboboxIndicatorGroup = withSlotContext<
 >('div', 'indicatorGroup')
 
 // -------------------- Empty --------------------
-export interface ComboboxEmptyProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCombobox.EmptyBaseProps>,
-    UnstyledProps {}
+export interface ComboboxEmptyProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCombobox.EmptyBaseProps
+> {}
 
 export const ComboboxEmpty = withSlotContext<
   HTMLDivElement,
@@ -210,10 +207,10 @@ export const ComboboxEmpty = withSlotContext<
 >(ArkCombobox.Empty, 'empty')
 
 // // -------------------- List --------------------
-export interface ComboboxListrProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkCombobox.ListBaseProps>,
-    UnstyledProps {}
+export interface ComboboxListrProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkCombobox.ListBaseProps
+> {}
 
 export const ComboboxList = withSlotContext<HTMLDivElement, ComboboxListrProps>(
   ArkCombobox.List,

--- a/packages/fidely-ui/src/components/dialog/dialog.tsx
+++ b/packages/fidely-ui/src/components/dialog/dialog.tsx
@@ -5,7 +5,7 @@ import { type Assign } from '@ark-ui/react'
 import { ark, HTMLArkProps } from '@ark-ui/react/factory'
 import { Dialog as ArkDialog, useDialogContext } from '@ark-ui/react/dialog'
 import { dialog, type DialogVariantProps } from 'styled-system/recipes'
-import type { UnstyledProps, HTMLStyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { styled } from 'styled-system/jsx'
 
 import { makeStyleContext } from '../../system/make-style-context'
@@ -13,26 +13,28 @@ import { makeStyleContext } from '../../system/make-style-context'
 const { withSlotRootProvider, withSlotContext } = makeStyleContext(dialog)
 
 // -------------------- RootProvider --------------------
-export interface DialogRootProviderProps
-  extends
-    Assign<ArkDialog.RootProviderProps, DialogVariantProps>,
-    UnstyledProps {}
+export interface DialogRootProviderProps extends Assign<
+  ArkDialog.RootProviderProps,
+  DialogVariantProps
+> {}
 
 export const DialogRootProvider = withSlotRootProvider<DialogRootProviderProps>(
   ArkDialog.RootProvider
 )
 
 // -------------------- Root --------------------
-export interface DialogRootProps
-  extends Assign<ArkDialog.RootProps, DialogVariantProps>, UnstyledProps {}
+export interface DialogRootProps extends Assign<
+  ArkDialog.RootProps,
+  DialogVariantProps
+> {}
 
 export const DialogRoot = withSlotRootProvider<DialogRootProps>(ArkDialog.Root)
 
 // -------------------- Content --------------------
-export interface DialogContentProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkDialog.ContentBaseProps>,
-    UnstyledProps {}
+export interface DialogContentProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkDialog.ContentBaseProps
+> {}
 
 export const DialogContent = withSlotContext<
   HTMLDivElement,
@@ -40,10 +42,10 @@ export const DialogContent = withSlotContext<
 >(ArkDialog.Content, 'content')
 
 // -------------------- Description --------------------
-export interface DialogDescriptionProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkDialog.DescriptionBaseProps>,
-    UnstyledProps {}
+export interface DialogDescriptionProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkDialog.DescriptionBaseProps
+> {}
 
 export const DialogDescription = withSlotContext<
   HTMLDivElement,
@@ -51,10 +53,10 @@ export const DialogDescription = withSlotContext<
 >(ArkDialog.Description, 'description')
 
 // -------------------- Title --------------------
-export interface DialogTitleProps
-  extends
-    Assign<HTMLStyledProps<'h2'>, ArkDialog.TitleBaseProps>,
-    UnstyledProps {}
+export interface DialogTitleProps extends Assign<
+  HTMLStyledProps<'h2'>,
+  ArkDialog.TitleBaseProps
+> {}
 
 export const DialogTitle = withSlotContext<
   HTMLHeadingElement,
@@ -62,10 +64,10 @@ export const DialogTitle = withSlotContext<
 >(ArkDialog.Title, 'title')
 
 // -------------------- CloseTrigger --------------------
-export interface DialogCloseTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkDialog.CloseTriggerBaseProps>,
-    UnstyledProps {}
+export interface DialogCloseTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkDialog.CloseTriggerBaseProps
+> {}
 
 export const DialogCloseTrigger = withSlotContext<
   HTMLButtonElement,
@@ -73,10 +75,10 @@ export const DialogCloseTrigger = withSlotContext<
 >(ArkDialog.CloseTrigger, 'closeTrigger')
 
 // -------------------- Trigger --------------------
-export interface DialogTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkDialog.TriggerBaseProps>,
-    UnstyledProps {}
+export interface DialogTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkDialog.TriggerBaseProps
+> {}
 
 export const DialogTrigger = withSlotContext<
   HTMLButtonElement,
@@ -84,8 +86,7 @@ export const DialogTrigger = withSlotContext<
 >(ArkDialog.Trigger, 'trigger')
 
 // -------------------- CloseAction --------------------
-export interface DialogCloseActionProps
-  extends HTMLArkProps<'button'>, UnstyledProps {}
+export interface DialogCloseActionProps extends HTMLArkProps<'button'> {}
 
 const StyledCloseAction = styled(ark.button)
 
@@ -105,10 +106,10 @@ export const DialogCloseAction = forwardRef<
 })
 
 // -------------------- Positioner --------------------
-export interface DialogPositionerProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkDialog.PositionerBaseProps>,
-    UnstyledProps {}
+export interface DialogPositionerProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkDialog.PositionerBaseProps
+> {}
 
 export const DialogPositioner = withSlotContext<
   HTMLDivElement,
@@ -116,10 +117,10 @@ export const DialogPositioner = withSlotContext<
 >(ArkDialog.Positioner, 'positioner')
 
 // -------------------- Backdrop --------------------
-export interface DialogBackdropProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkDialog.BackdropBaseProps>,
-    UnstyledProps {}
+export interface DialogBackdropProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkDialog.BackdropBaseProps
+> {}
 
 export const DialogBackdrop = withSlotContext<
   HTMLDivElement,
@@ -127,8 +128,7 @@ export const DialogBackdrop = withSlotContext<
 >(ArkDialog.Backdrop, 'backdrop')
 
 // -------------------- Body --------------------
-export interface DialogBodyProps
-  extends HTMLStyledProps<'div'>, UnstyledProps {}
+export interface DialogBodyProps extends HTMLStyledProps<'div'> {}
 
 export const DialogBody = withSlotContext<HTMLDivElement, DialogBodyProps>(
   'div',
@@ -136,8 +136,7 @@ export const DialogBody = withSlotContext<HTMLDivElement, DialogBodyProps>(
 )
 
 // -------------------- Header --------------------
-export interface DialogHeaderProps
-  extends HTMLStyledProps<'div'>, UnstyledProps {}
+export interface DialogHeaderProps extends HTMLStyledProps<'div'> {}
 
 export const DialogHeader = withSlotContext<HTMLDivElement, DialogHeaderProps>(
   'div',
@@ -145,8 +144,7 @@ export const DialogHeader = withSlotContext<HTMLDivElement, DialogHeaderProps>(
 )
 
 // -------------------- Footer --------------------
-export interface DialogFooterProps
-  extends HTMLStyledProps<'div'>, UnstyledProps {}
+export interface DialogFooterProps extends HTMLStyledProps<'div'> {}
 
 export const DialogFooter = withSlotContext<HTMLDivElement, DialogFooterProps>(
   'div',

--- a/packages/fidely-ui/src/components/divider/index.tsx
+++ b/packages/fidely-ui/src/components/divider/index.tsx
@@ -3,7 +3,8 @@
 import { forwardRef } from 'react'
 import { type PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
-import { HTMLStyledProps, styled } from 'styled-system/jsx'
+import { styled } from 'styled-system/jsx'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { divider, type DividerProperties } from 'styled-system/patterns'
 
 import { splitProps } from '../../utils/split-props'

--- a/packages/fidely-ui/src/components/field/field.tsx
+++ b/packages/fidely-ui/src/components/field/field.tsx
@@ -5,7 +5,7 @@ import type { Assign, HTMLArkProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
 import { Field as ArkField, useFieldContext } from '@ark-ui/react/field'
 import { field, type FieldVariantProps } from 'styled-system/recipes'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { cx } from 'styled-system/css'
 
 import { makeStyleContext } from '../../system/make-style-context'
@@ -13,13 +13,10 @@ import { makeStyleContext } from '../../system/make-style-context'
 const { withSlotProvider, withSlotContext } = makeStyleContext(field)
 
 // -------------------- RootProvider --------------------
-export interface FieldRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkField.RootProviderBaseProps>,
-      FieldVariantProps
-    >,
-    UnstyledProps {}
+export interface FieldRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkField.RootProviderBaseProps>,
+  FieldVariantProps
+> {}
 
 export const FieldRootProvider = withSlotProvider<
   HTMLDivElement,
@@ -27,13 +24,10 @@ export const FieldRootProvider = withSlotProvider<
 >(ArkField.RootProvider, 'root')
 
 // -------------------- Root --------------------
-export interface FieldRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkField.RootBaseProps>,
-      FieldVariantProps
-    >,
-    UnstyledProps {}
+export interface FieldRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkField.RootBaseProps>,
+  FieldVariantProps
+> {}
 
 export const FieldRoot = withSlotProvider<HTMLDivElement, FieldRootProps>(
   ArkField.Root,
@@ -41,10 +35,10 @@ export const FieldRoot = withSlotProvider<HTMLDivElement, FieldRootProps>(
 )
 
 // -------------------- Error --------------------
-export interface FieldErrorProps
-  extends
-    Assign<HTMLStyledProps<'span'>, ArkField.ErrorTextBaseProps>,
-    UnstyledProps {}
+export interface FieldErrorProps extends Assign<
+  HTMLStyledProps<'span'>,
+  ArkField.ErrorTextBaseProps
+> {}
 
 export const FieldError = withSlotContext<HTMLSpanElement, FieldErrorProps>(
   ArkField.ErrorText,
@@ -52,10 +46,10 @@ export const FieldError = withSlotContext<HTMLSpanElement, FieldErrorProps>(
 )
 
 // -------------------- HelperText --------------------
-export interface FieldHelperTextProps
-  extends
-    Assign<HTMLStyledProps<'span'>, ArkField.HelperTextBaseProps>,
-    UnstyledProps {}
+export interface FieldHelperTextProps extends Assign<
+  HTMLStyledProps<'span'>,
+  ArkField.HelperTextBaseProps
+> {}
 
 export const FieldHelperText = withSlotContext<
   HTMLSpanElement,
@@ -63,10 +57,10 @@ export const FieldHelperText = withSlotContext<
 >(ArkField.HelperText, 'helperText')
 
 // -------------------- Label --------------------
-export interface FieldLabelProps
-  extends
-    Assign<HTMLStyledProps<'label'>, ArkField.LabelBaseProps>,
-    UnstyledProps {}
+export interface FieldLabelProps extends Assign<
+  HTMLStyledProps<'label'>,
+  ArkField.LabelBaseProps
+> {}
 
 export const FieldLabel = withSlotContext<HTMLLabelElement, FieldLabelProps>(
   ArkField.Label,
@@ -74,8 +68,7 @@ export const FieldLabel = withSlotContext<HTMLLabelElement, FieldLabelProps>(
 )
 
 // -------------------- Indicator --------------------
-export interface FieldRequiredIndicatorProps
-  extends HTMLArkProps<'span'>, UnstyledProps {
+export interface FieldRequiredIndicatorProps extends HTMLArkProps<'span'> {
   fallback?: React.ReactNode | undefined
 }
 

--- a/packages/fidely-ui/src/components/flex/index.tsx
+++ b/packages/fidely-ui/src/components/flex/index.tsx
@@ -3,7 +3,8 @@
 import { forwardRef } from 'react'
 import { type PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
-import { HTMLStyledProps, styled } from 'styled-system/jsx'
+import { styled } from 'styled-system/jsx'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { flex, type FlexProperties } from 'styled-system/patterns'
 
 import { splitProps } from '../../utils/split-props'

--- a/packages/fidely-ui/src/components/grid/grid.tsx
+++ b/packages/fidely-ui/src/components/grid/grid.tsx
@@ -3,7 +3,8 @@
 import { forwardRef } from 'react'
 import { type PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
-import { HTMLStyledProps, styled } from 'styled-system/jsx'
+import { styled } from 'styled-system/jsx'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { grid, type GridProperties } from 'styled-system/patterns'
 
 import { splitProps } from '../../utils/split-props'

--- a/packages/fidely-ui/src/components/grid/gridItem.tsx
+++ b/packages/fidely-ui/src/components/grid/gridItem.tsx
@@ -3,7 +3,8 @@
 import { forwardRef } from 'react'
 import { type PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
-import { HTMLStyledProps, styled } from 'styled-system/jsx'
+import { styled } from 'styled-system/jsx'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { gridItem, type GridItemProperties } from 'styled-system/patterns'
 
 import { splitProps } from '../../utils/split-props'

--- a/packages/fidely-ui/src/components/hover-card/hover-card.tsx
+++ b/packages/fidely-ui/src/components/hover-card/hover-card.tsx
@@ -3,42 +3,36 @@
 import type { Assign } from '@ark-ui/react'
 import { HoverCard as ArkHoverCard } from '@ark-ui/react/hover-card'
 import { hoverCard, type HoverCardVariantProps } from 'styled-system/recipes'
-import { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 
 import { makeStyleContext } from '../../system/make-style-context'
 
 const { withSlotRootProvider, withSlotContext } = makeStyleContext(hoverCard)
 
 // -------------------- RootProvider --------------------
-export interface HoverCardRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkHoverCard.RootProviderBaseProps>,
-      HoverCardVariantProps
-    >,
-    UnstyledProps {}
+export interface HoverCardRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkHoverCard.RootProviderBaseProps>,
+  HoverCardVariantProps
+> {}
 
 export const HoverCardRootProvider =
   withSlotRootProvider<HoverCardRootProviderProps>(ArkHoverCard.RootProvider)
 
 // -------------------- Root --------------------
-export interface HoverCardRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkHoverCard.RootBaseProps>,
-      HoverCardVariantProps
-    >,
-    UnstyledProps {}
+export interface HoverCardRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkHoverCard.RootBaseProps>,
+  HoverCardVariantProps
+> {}
 
 export const HoverCardRoot = withSlotRootProvider<HoverCardRootProps>(
   ArkHoverCard.Root
 )
 
 // -------------------- Content --------------------
-export interface HoverCardContentProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkHoverCard.ContentBaseProps>,
-    UnstyledProps {}
+export interface HoverCardContentProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkHoverCard.ContentBaseProps
+> {}
 
 export const HoverCardContent = withSlotContext<
   HTMLDivElement,
@@ -46,10 +40,10 @@ export const HoverCardContent = withSlotContext<
 >(ArkHoverCard.Content, 'content')
 
 // -------------------- Trigger --------------------
-export interface HoverCardTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkHoverCard.TriggerBaseProps>,
-    UnstyledProps {}
+export interface HoverCardTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkHoverCard.TriggerBaseProps
+> {}
 
 export const HoverCardTrigger = withSlotContext<
   HTMLButtonElement,
@@ -57,10 +51,10 @@ export const HoverCardTrigger = withSlotContext<
 >(ArkHoverCard.Trigger, 'trigger')
 
 // -------------------- Positioner --------------------
-export interface HoverCardPositionerProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkHoverCard.PositionerBaseProps>,
-    UnstyledProps {}
+export interface HoverCardPositionerProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkHoverCard.PositionerBaseProps
+> {}
 
 export const HoverCardPositioner = withSlotContext<
   HTMLDivElement,
@@ -68,10 +62,10 @@ export const HoverCardPositioner = withSlotContext<
 >(ArkHoverCard.Positioner, 'positioner')
 
 // -------------------- ArrowTip --------------------
-export interface HoverCardArrowTipProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkHoverCard.ArrowTipBaseProps>,
-    UnstyledProps {}
+export interface HoverCardArrowTipProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkHoverCard.ArrowTipBaseProps
+> {}
 
 export const HoverCardArrowTip = withSlotContext<
   HTMLDivElement,
@@ -79,10 +73,10 @@ export const HoverCardArrowTip = withSlotContext<
 >(ArkHoverCard.ArrowTip, 'arrowTip')
 
 // -------------------- Arrow --------------------
-export interface HoverCardArrowProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkHoverCard.ArrowBaseProps>,
-    UnstyledProps {}
+export interface HoverCardArrowProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkHoverCard.ArrowBaseProps
+> {}
 
 export const HoverCardArrow = withSlotContext<
   HTMLDivElement,

--- a/packages/fidely-ui/src/components/marquee/marquee.tsx
+++ b/packages/fidely-ui/src/components/marquee/marquee.tsx
@@ -3,21 +3,17 @@
 import type { Assign } from '@ark-ui/react'
 import { Marquee as ArkMarquee } from '@ark-ui/react/marquee'
 import { marquee, type MarqueeVariantProps } from 'styled-system/recipes'
-import type { HTMLStyledProps } from 'styled-system/jsx'
+import { type HTMLStyledProps } from 'styled-system/types'
 
 import { makeStyleContext } from '../../system/make-style-context'
-import { UnstyledProps } from 'styled-system/types'
 
 const { withSlotProvider, withSlotContext } = makeStyleContext(marquee)
 
 // -------------------- RootProvider --------------------
-export interface MarqueeRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkMarquee.RootProviderBaseProps>,
-      MarqueeVariantProps
-    >,
-    UnstyledProps {}
+export interface MarqueeRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkMarquee.RootProviderBaseProps>,
+  MarqueeVariantProps
+> {}
 
 export const MarqueeRootProvider = withSlotProvider<
   HTMLDivElement,
@@ -25,13 +21,10 @@ export const MarqueeRootProvider = withSlotProvider<
 >(ArkMarquee.RootProvider, 'root')
 
 // -------------------- Root --------------------
-export interface MarqueeRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkMarquee.RootBaseProps>,
-      MarqueeVariantProps
-    >,
-    UnstyledProps {}
+export interface MarqueeRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkMarquee.RootBaseProps>,
+  MarqueeVariantProps
+> {}
 
 export const MarqueeRoot = withSlotProvider<HTMLDivElement, MarqueeRootProps>(
   ArkMarquee.Root,
@@ -39,10 +32,10 @@ export const MarqueeRoot = withSlotProvider<HTMLDivElement, MarqueeRootProps>(
 )
 
 // -------------------- Viewport --------------------
-export interface MarqueeViewportProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMarquee.ViewportBaseProps>,
-    UnstyledProps {}
+export interface MarqueeViewportProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMarquee.ViewportBaseProps
+> {}
 
 export const MarqueeViewport = withSlotContext<
   HTMLDivElement,
@@ -50,10 +43,10 @@ export const MarqueeViewport = withSlotContext<
 >(ArkMarquee.Viewport, 'viewport')
 
 // -------------------- Content --------------------
-export interface MarqueeContentProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMarquee.ContentBaseProps>,
-    UnstyledProps {}
+export interface MarqueeContentProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMarquee.ContentBaseProps
+> {}
 
 export const MarqueeContent = withSlotContext<
   HTMLDivElement,
@@ -61,10 +54,10 @@ export const MarqueeContent = withSlotContext<
 >(ArkMarquee.Content, 'content')
 
 // -------------------- Item --------------------
-export interface MarqueeItemProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMarquee.ItemBaseProps>,
-    UnstyledProps {}
+export interface MarqueeItemProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMarquee.ItemBaseProps
+> {}
 
 export const MarqueeItem = withSlotContext<HTMLDivElement, MarqueeItemProps>(
   ArkMarquee.Item,
@@ -72,10 +65,10 @@ export const MarqueeItem = withSlotContext<HTMLDivElement, MarqueeItemProps>(
 )
 
 // -------------------- Edge --------------------
-export interface MarqueeEdgeProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMarquee.EdgeBaseProps>,
-    UnstyledProps {}
+export interface MarqueeEdgeProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMarquee.EdgeBaseProps
+> {}
 
 export const MarqueeEdge = withSlotContext<HTMLDivElement, MarqueeEdgeProps>(
   ArkMarquee.Edge,

--- a/packages/fidely-ui/src/components/menu/menu.tsx
+++ b/packages/fidely-ui/src/components/menu/menu.tsx
@@ -3,7 +3,7 @@
 import type { Assign } from '@ark-ui/react'
 import { Menu as ArkMenu } from '@ark-ui/react/menu'
 import { menu, type MenuVariantProps } from 'styled-system/recipes'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 
 import { makeStyleContext } from '../../system/make-style-context'
 import { FiCaretDownIcon } from '../../icons/FiCaretDownIcon'
@@ -11,34 +11,28 @@ import { FiCaretDownIcon } from '../../icons/FiCaretDownIcon'
 const { withSlotRootProvider, withSlotContext } = makeStyleContext(menu)
 
 // -------------------- RootProvider --------------------
-export interface MenuRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkMenu.RootProviderBaseProps>,
-      MenuVariantProps
-    >,
-    UnstyledProps {}
+export interface MenuRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkMenu.RootProviderBaseProps>,
+  MenuVariantProps
+> {}
 
 export const MenuRootProvider = withSlotRootProvider<MenuRootProviderProps>(
   ArkMenu.RootProvider
 )
 
 // -------------------- Root --------------------
-export interface MenuRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkMenu.RootBaseProps>,
-      MenuVariantProps
-    >,
-    UnstyledProps {}
+export interface MenuRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkMenu.RootBaseProps>,
+  MenuVariantProps
+> {}
 
 export const MenuRoot = withSlotRootProvider<MenuRootProps>(ArkMenu.Root)
 
 // -------------------- Content --------------------
-export interface MenuContentProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.ContentBaseProps>,
-    UnstyledProps {}
+export interface MenuContentProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.ContentBaseProps
+> {}
 
 export const MenuContent = withSlotContext<HTMLDivElement, MenuContentProps>(
   ArkMenu.Content,
@@ -46,10 +40,10 @@ export const MenuContent = withSlotContext<HTMLDivElement, MenuContentProps>(
 )
 
 // -------------------- Trigger --------------------
-export interface MenuTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkMenu.TriggerBaseProps>,
-    UnstyledProps {}
+export interface MenuTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkMenu.TriggerBaseProps
+> {}
 
 export const MenuTrigger = withSlotContext<HTMLButtonElement, MenuTriggerProps>(
   ArkMenu.Trigger,
@@ -57,10 +51,10 @@ export const MenuTrigger = withSlotContext<HTMLButtonElement, MenuTriggerProps>(
 )
 
 // -------------------- ContextTrigger --------------------
-export interface MenuContextTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkMenu.ContextTriggerBaseProps>,
-    UnstyledProps {}
+export interface MenuContextTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkMenu.ContextTriggerBaseProps
+> {}
 
 export const MenuContextTrigger = withSlotContext<
   HTMLButtonElement,
@@ -68,10 +62,10 @@ export const MenuContextTrigger = withSlotContext<
 >(ArkMenu.ContextTrigger, 'contextTrigger')
 
 // -------------------- TriggerItem --------------------
-export interface MenuTriggerItemProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.TriggerItemBaseProps>,
-    UnstyledProps {}
+export interface MenuTriggerItemProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.TriggerItemBaseProps
+> {}
 
 export const MenuTriggerItem = withSlotContext<
   HTMLDivElement,
@@ -79,10 +73,10 @@ export const MenuTriggerItem = withSlotContext<
 >(ArkMenu.TriggerItem, 'triggerItem')
 
 // -------------------- Separator --------------------
-export interface MenuSeparatorProps
-  extends
-    Assign<HTMLStyledProps<'hr'>, ArkMenu.SeparatorBaseProps>,
-    UnstyledProps {}
+export interface MenuSeparatorProps extends Assign<
+  HTMLStyledProps<'hr'>,
+  ArkMenu.SeparatorBaseProps
+> {}
 
 export const MenuSeparator = withSlotContext<HTMLHRElement, MenuSeparatorProps>(
   ArkMenu.Separator,
@@ -90,10 +84,10 @@ export const MenuSeparator = withSlotContext<HTMLHRElement, MenuSeparatorProps>(
 )
 
 // -------------------- Positioner --------------------
-export interface MenuPositionerProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.PositionerBaseProps>,
-    UnstyledProps {}
+export interface MenuPositionerProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.PositionerBaseProps
+> {}
 
 export const MenuPositioner = withSlotContext<
   HTMLDivElement,
@@ -101,10 +95,10 @@ export const MenuPositioner = withSlotContext<
 >(ArkMenu.Positioner, 'positioner')
 
 // -------------------- Item --------------------
-export interface MenuItemProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.ItemBaseProps>,
-    UnstyledProps {}
+export interface MenuItemProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.ItemBaseProps
+> {}
 
 export const MenuItem = withSlotContext<HTMLDivElement, MenuItemProps>(
   ArkMenu.Item,
@@ -112,10 +106,10 @@ export const MenuItem = withSlotContext<HTMLDivElement, MenuItemProps>(
 )
 
 // -------------------- ItemText --------------------
-export interface MenuItemTextProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.ItemTextBaseProps>,
-    UnstyledProps {}
+export interface MenuItemTextProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.ItemTextBaseProps
+> {}
 
 export const MenuItemText = withSlotContext<HTMLDivElement, MenuItemTextProps>(
   ArkMenu.ItemText,
@@ -123,10 +117,10 @@ export const MenuItemText = withSlotContext<HTMLDivElement, MenuItemTextProps>(
 )
 
 // -------------------- ItemGroup --------------------
-export interface MenuItemGroupProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.ItemGroupProps>,
-    UnstyledProps {}
+export interface MenuItemGroupProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.ItemGroupProps
+> {}
 
 export const MenuItemGroup = withSlotContext<
   HTMLDivElement,
@@ -134,10 +128,10 @@ export const MenuItemGroup = withSlotContext<
 >(ArkMenu.ItemGroup, 'itemGroup')
 
 // -------------------- ItemGroupLabel --------------------
-export interface MenuItemGroupLabelProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.ItemGroupLabelBaseProps>,
-    UnstyledProps {}
+export interface MenuItemGroupLabelProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.ItemGroupLabelBaseProps
+> {}
 
 export const MenuItemGroupLabel = withSlotContext<
   HTMLDivElement,
@@ -145,10 +139,10 @@ export const MenuItemGroupLabel = withSlotContext<
 >(ArkMenu.ItemGroupLabel, 'itemGroupLabel')
 
 // -------------------- CheckboxItem --------------------
-export interface MenuCheckboxItemProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.CheckboxItemBaseProps>,
-    UnstyledProps {}
+export interface MenuCheckboxItemProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.CheckboxItemBaseProps
+> {}
 
 export const MenuCheckboxItem = withSlotContext<
   HTMLDivElement,
@@ -156,10 +150,10 @@ export const MenuCheckboxItem = withSlotContext<
 >(ArkMenu.CheckboxItem, 'item')
 
 // -------------------- RadioItem --------------------
-export interface MenuRadioItemProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.RadioItemBaseProps>,
-    UnstyledProps {}
+export interface MenuRadioItemProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.RadioItemBaseProps
+> {}
 
 export const MenuRadioItem = withSlotContext<
   HTMLDivElement,
@@ -167,10 +161,10 @@ export const MenuRadioItem = withSlotContext<
 >(ArkMenu.RadioItem, 'item')
 
 // -------------------- RadioItemGroup --------------------
-export interface MenuRadioItemGroupProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.RadioItemGroupBaseProps>,
-    UnstyledProps {}
+export interface MenuRadioItemGroupProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.RadioItemGroupBaseProps
+> {}
 
 export const MenuRadioItemGroup = withSlotContext<
   HTMLDivElement,
@@ -178,10 +172,10 @@ export const MenuRadioItemGroup = withSlotContext<
 >(ArkMenu.RadioItemGroup, 'itemGroup')
 
 // -------------------- Indicator --------------------
-export interface MenuIndicatorProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.IndicatorBaseProps>,
-    UnstyledProps {
+export interface MenuIndicatorProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.IndicatorBaseProps
+> {
   idleIcon?: React.ReactNode
 }
 
@@ -195,10 +189,10 @@ export const MenuIndicator = withSlotContext<
 }, 'indicator')
 
 // -------------------- ItemIndicator --------------------
-export interface MenuItemIndicatorProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.ItemIndicatorBaseProps>,
-    UnstyledProps {}
+export interface MenuItemIndicatorProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.ItemIndicatorBaseProps
+> {}
 
 export const MenuItemIndicator = withSlotContext<
   HTMLDivElement,
@@ -206,10 +200,10 @@ export const MenuItemIndicator = withSlotContext<
 >(ArkMenu.ItemIndicator, 'itemIndicator')
 
 // -------------------- MenuArrow --------------------
-export interface MenuArrowProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.ArrowBaseProps>,
-    UnstyledProps {}
+export interface MenuArrowProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.ArrowBaseProps
+> {}
 
 export const MenuArrow = withSlotContext<HTMLDivElement, MenuArrowProps>(
   ArkMenu.Arrow,
@@ -217,10 +211,10 @@ export const MenuArrow = withSlotContext<HTMLDivElement, MenuArrowProps>(
 )
 
 // -------------------- MenuArrowTip --------------------
-export interface MenuArrowTipProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkMenu.ArrowTipBaseProps>,
-    UnstyledProps {}
+export interface MenuArrowTipProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkMenu.ArrowTipBaseProps
+> {}
 
 export const MenuArrowTip = withSlotContext<HTMLDivElement, MenuArrowTipProps>(
   ArkMenu.ArrowTip,

--- a/packages/fidely-ui/src/components/password-input/password-input.tsx
+++ b/packages/fidely-ui/src/components/password-input/password-input.tsx
@@ -6,7 +6,7 @@ import {
   passwordInput,
   type PasswordInputVariantProps,
 } from 'styled-system/recipes'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 
 import { makeStyleContext } from '../../system/make-style-context'
 import { FiEyeIcon } from '../../icons/FiEyeIcon'
@@ -15,13 +15,10 @@ import { FiEyeSlashIcon } from '../../icons/FiEyeSlashIcon'
 const { withSlotProvider, withSlotContext } = makeStyleContext(passwordInput)
 
 // -------------------- RootProvider --------------------
-export interface PasswordInputRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkPasswordInput.RootProviderBaseProps>,
-      PasswordInputVariantProps
-    >,
-    UnstyledProps {}
+export interface PasswordInputRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkPasswordInput.RootProviderBaseProps>,
+  PasswordInputVariantProps
+> {}
 
 export const PasswordInputRootProvider = withSlotProvider<
   HTMLDivElement,
@@ -29,13 +26,10 @@ export const PasswordInputRootProvider = withSlotProvider<
 >(ArkPasswordInput.RootProvider, 'root')
 
 // -------------------- Root --------------------
-export interface PasswordInputRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkPasswordInput.RootBaseProps>,
-      PasswordInputVariantProps
-    >,
-    UnstyledProps {}
+export interface PasswordInputRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkPasswordInput.RootBaseProps>,
+  PasswordInputVariantProps
+> {}
 
 export const PasswordInputRoot = withSlotProvider<
   HTMLDivElement,
@@ -43,10 +37,10 @@ export const PasswordInputRoot = withSlotProvider<
 >(ArkPasswordInput.Root, 'root')
 
 // -------------------- Input --------------------
-export interface PasswordInputInputProps
-  extends
-    Assign<HTMLStyledProps<'input'>, ArkPasswordInput.InputBaseProps>,
-    UnstyledProps {}
+export interface PasswordInputInputProps extends Assign<
+  HTMLStyledProps<'input'>,
+  ArkPasswordInput.InputBaseProps
+> {}
 
 export const PasswordInputInput = withSlotContext<
   HTMLInputElement,
@@ -54,10 +48,10 @@ export const PasswordInputInput = withSlotContext<
 >(ArkPasswordInput.Input, 'input')
 
 // -------------------- Label --------------------
-export interface PasswordInputLabelProps
-  extends
-    Assign<HTMLStyledProps<'label'>, ArkPasswordInput.LabelBaseProps>,
-    UnstyledProps {}
+export interface PasswordInputLabelProps extends Assign<
+  HTMLStyledProps<'label'>,
+  ArkPasswordInput.LabelBaseProps
+> {}
 
 export const PasswordInputLabel = withSlotContext<
   HTMLLabelElement,
@@ -65,10 +59,10 @@ export const PasswordInputLabel = withSlotContext<
 >(ArkPasswordInput.Label, 'label')
 
 // -------------------- Control --------------------
-export interface PasswordInputControlProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkPasswordInput.ControlBaseProps>,
-    UnstyledProps {}
+export interface PasswordInputControlProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkPasswordInput.ControlBaseProps
+> {}
 
 export const PasswordInputControl = withSlotContext<
   HTMLDivElement,
@@ -76,10 +70,10 @@ export const PasswordInputControl = withSlotContext<
 >(ArkPasswordInput.Control, 'control')
 
 // -------------------- Indicator --------------------
-export interface PasswordInputIndicatorProps
-  extends
-    Assign<HTMLStyledProps<'span'>, ArkPasswordInput.IndicatorBaseProps>,
-    UnstyledProps {
+export interface PasswordInputIndicatorProps extends Assign<
+  HTMLStyledProps<'span'>,
+  ArkPasswordInput.IndicatorBaseProps
+> {
   fallbackIcon?: React.ReactNode
   idleIcon?: React.ReactNode
 }
@@ -106,13 +100,10 @@ export const PasswordInputIndicator = withSlotContext<
 }, 'indicator')
 
 // -------------------- VisibilityTrigger --------------------
-export interface PasswordInputVisibilityTriggerProps
-  extends
-    Assign<
-      HTMLStyledProps<'button'>,
-      ArkPasswordInput.VisibilityTriggerBaseProps
-    >,
-    UnstyledProps {}
+export interface PasswordInputVisibilityTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkPasswordInput.VisibilityTriggerBaseProps
+> {}
 
 export const PasswordInputVisibilityTrigger = withSlotContext<
   HTMLButtonElement,

--- a/packages/fidely-ui/src/components/pin-input/pin-input.tsx
+++ b/packages/fidely-ui/src/components/pin-input/pin-input.tsx
@@ -3,32 +3,26 @@
 import type { Assign } from '@ark-ui/react'
 import { PinInput as ArkPinInput } from '@ark-ui/react/pin-input'
 import { pinInput, type PinInputVariantProps } from 'styled-system/recipes'
-import { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 
 import { makeStyleContext } from '../../system/make-style-context'
 
 const { withSlotProvider, withSlotContext } = makeStyleContext(pinInput)
 
-export interface PinInputRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkPinInput.RootProviderBaseProps>,
-      PinInputVariantProps
-    >,
-    UnstyledProps {}
+export interface PinInputRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkPinInput.RootProviderBaseProps>,
+  PinInputVariantProps
+> {}
 
 export const PinInputRootProvider = withSlotProvider<
   HTMLDivElement,
   PinInputRootProviderProps
 >(ArkPinInput.RootProvider, 'root')
 
-export interface PinInputRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkPinInput.RootBaseProps>,
-      PinInputVariantProps
-    >,
-    UnstyledProps {}
+export interface PinInputRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkPinInput.RootBaseProps>,
+  PinInputVariantProps
+> {}
 
 export const PinInputRoot = withSlotProvider<HTMLDivElement, PinInputRootProps>(
   ArkPinInput.Root,
@@ -36,30 +30,30 @@ export const PinInputRoot = withSlotProvider<HTMLDivElement, PinInputRootProps>(
   { forwardProps: ['mask'] }
 )
 
-export interface PinInputLabelProps
-  extends
-    Assign<HTMLStyledProps<'label'>, ArkPinInput.LabelBaseProps>,
-    UnstyledProps {}
+export interface PinInputLabelProps extends Assign<
+  HTMLStyledProps<'label'>,
+  ArkPinInput.LabelBaseProps
+> {}
 
 export const PinInputLabel = withSlotContext<
   HTMLLabelElement,
   PinInputLabelProps
 >(ArkPinInput.Label, 'label')
 
-export interface PinInputControlProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkPinInput.ControlBaseProps>,
-    UnstyledProps {}
+export interface PinInputControlProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkPinInput.ControlBaseProps
+> {}
 
 export const PinInputControl = withSlotContext<
   HTMLDivElement,
   PinInputControlProps
 >(ArkPinInput.Control, 'control')
 
-export interface PinInputInputProps
-  extends
-    Assign<HTMLStyledProps<'input'>, ArkPinInput.InputBaseProps>,
-    UnstyledProps {}
+export interface PinInputInputProps extends Assign<
+  HTMLStyledProps<'input'>,
+  ArkPinInput.InputBaseProps
+> {}
 
 export const PinInputInput = withSlotContext<
   HTMLInputElement,

--- a/packages/fidely-ui/src/components/popover/popover.tsx
+++ b/packages/fidely-ui/src/components/popover/popover.tsx
@@ -3,42 +3,36 @@
 import type { Assign } from '@ark-ui/react'
 import { Popover as ArkPopover } from '@ark-ui/react/popover'
 import { popover, type PopoverVariantProps } from 'styled-system/recipes'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 
 import { makeStyleContext } from '../../system/make-style-context'
 
 const { withSlotRootProvider, withSlotContext } = makeStyleContext(popover)
 
 // -------------------- RootProvider --------------------
-export interface PopoverRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkPopover.RootProviderBaseProps>,
-      PopoverVariantProps
-    >,
-    UnstyledProps {}
+export interface PopoverRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkPopover.RootProviderBaseProps>,
+  PopoverVariantProps
+> {}
 
 export const PopoverRootProvider =
   withSlotRootProvider<PopoverRootProviderProps>(ArkPopover.RootProvider)
 
 // -------------------- Root --------------------
-export interface PopoverRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkPopover.RootBaseProps>,
-      PopoverVariantProps
-    >,
-    UnstyledProps {}
+export interface PopoverRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkPopover.RootBaseProps>,
+  PopoverVariantProps
+> {}
 
 export const PopoverRoot = withSlotRootProvider<PopoverRootProps>(
   ArkPopover.Root
 )
 
 // -------------------- Content --------------------
-export interface PopoverContentProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkPopover.ContentBaseProps>,
-    UnstyledProps {}
+export interface PopoverContentProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkPopover.ContentBaseProps
+> {}
 
 export const PopoverContent = withSlotContext<
   HTMLDivElement,
@@ -46,10 +40,10 @@ export const PopoverContent = withSlotContext<
 >(ArkPopover.Content, 'content')
 
 // -------------------- Trigger --------------------
-export interface PopoverTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkPopover.TriggerBaseProps>,
-    UnstyledProps {}
+export interface PopoverTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkPopover.TriggerBaseProps
+> {}
 
 export const PopoverTrigger = withSlotContext<
   HTMLButtonElement,
@@ -57,10 +51,10 @@ export const PopoverTrigger = withSlotContext<
 >(ArkPopover.Trigger, 'trigger')
 
 // -------------------- CloseTrigger --------------------
-export interface PopoverCloseTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkPopover.CloseTriggerBaseProps>,
-    UnstyledProps {}
+export interface PopoverCloseTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkPopover.CloseTriggerBaseProps
+> {}
 
 export const PopoverCloseTrigger = withSlotContext<
   HTMLButtonElement,
@@ -68,10 +62,10 @@ export const PopoverCloseTrigger = withSlotContext<
 >(ArkPopover.CloseTrigger, 'closeTrigger')
 
 // -------------------- Positioner --------------------
-export interface PopoverPositionerProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkPopover.PositionerBaseProps>,
-    UnstyledProps {}
+export interface PopoverPositionerProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkPopover.PositionerBaseProps
+> {}
 
 export const PopoverPositioner = withSlotContext<
   HTMLDivElement,
@@ -79,10 +73,10 @@ export const PopoverPositioner = withSlotContext<
 >(ArkPopover.Positioner, 'positioner')
 
 // -------------------- ArrowTip --------------------
-export interface PopoverArrowTipProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkPopover.ArrowTipBaseProps>,
-    UnstyledProps {}
+export interface PopoverArrowTipProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkPopover.ArrowTipBaseProps
+> {}
 
 export const PopoverArrowTip = withSlotContext<
   HTMLDivElement,
@@ -90,10 +84,10 @@ export const PopoverArrowTip = withSlotContext<
 >(ArkPopover.ArrowTip, 'arrowTip')
 
 // -------------------- Arrow --------------------
-export interface PopoverArrowProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkPopover.ArrowBaseProps>,
-    UnstyledProps {}
+export interface PopoverArrowProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkPopover.ArrowBaseProps
+> {}
 
 export const PopoverArrow = withSlotContext<HTMLDivElement, PopoverArrowProps>(
   ArkPopover.Arrow,
@@ -101,10 +95,10 @@ export const PopoverArrow = withSlotContext<HTMLDivElement, PopoverArrowProps>(
 )
 
 // -------------------- Description --------------------
-export interface PopoverDescriptionProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkPopover.DescriptionBaseProps>,
-    UnstyledProps {}
+export interface PopoverDescriptionProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkPopover.DescriptionBaseProps
+> {}
 
 export const PopoverDescription = withSlotContext<
   HTMLDivElement,
@@ -112,10 +106,10 @@ export const PopoverDescription = withSlotContext<
 >(ArkPopover.Description, 'description')
 
 // -------------------- Title --------------------
-export interface PopoverTitleProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkPopover.TitleBaseProps>,
-    UnstyledProps {}
+export interface PopoverTitleProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkPopover.TitleBaseProps
+> {}
 
 export const PopoverTitle = withSlotContext<HTMLDivElement, PopoverTitleProps>(
   ArkPopover.Title,
@@ -123,10 +117,10 @@ export const PopoverTitle = withSlotContext<HTMLDivElement, PopoverTitleProps>(
 )
 
 // -------------------- Indicator --------------------
-export interface PopoverIndicatorProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkPopover.IndicatorBaseProps>,
-    UnstyledProps {}
+export interface PopoverIndicatorProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkPopover.IndicatorBaseProps
+> {}
 
 export const PopoverIndicator = withSlotContext<
   HTMLDivElement,
@@ -134,10 +128,10 @@ export const PopoverIndicator = withSlotContext<
 >(ArkPopover.Indicator, 'indicator')
 
 // -------------------- Anchor --------------------
-export interface PopoverAnchorProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkPopover.AnchorBaseProps>,
-    UnstyledProps {}
+export interface PopoverAnchorProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkPopover.AnchorBaseProps
+> {}
 
 export const PopoverAnchor = withSlotContext<
   HTMLDivElement,

--- a/packages/fidely-ui/src/components/profile/profile.tsx
+++ b/packages/fidely-ui/src/components/profile/profile.tsx
@@ -2,7 +2,7 @@
 
 import type { Assign, PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { profile, type ProfileVariantProps } from 'styled-system/recipes'
 
 import { makeStyleContext } from '../../system/make-style-context'
@@ -10,13 +10,10 @@ import { makeStyleContext } from '../../system/make-style-context'
 const { withSlotProvider, withSlotContext } = makeStyleContext(profile)
 
 // -------------------- Root --------------------
-export interface ProfileRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, PolymorphicProps>,
-      ProfileVariantProps
-    >,
-    UnstyledProps {}
+export interface ProfileRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, PolymorphicProps>,
+  ProfileVariantProps
+> {}
 
 export const ProfileRoot = withSlotProvider<HTMLDivElement, ProfileRootProps>(
   ark.div,
@@ -24,8 +21,10 @@ export const ProfileRoot = withSlotProvider<HTMLDivElement, ProfileRootProps>(
 )
 
 // -------------------- Details --------------------
-export interface ProfileDetailsProps
-  extends Assign<HTMLStyledProps<'div'>, PolymorphicProps>, UnstyledProps {}
+export interface ProfileDetailsProps extends Assign<
+  HTMLStyledProps<'div'>,
+  PolymorphicProps
+> {}
 
 export const ProfileDetails = withSlotContext<
   HTMLDivElement,
@@ -33,8 +32,10 @@ export const ProfileDetails = withSlotContext<
 >(ark.div, 'details')
 
 // -------------------- Name --------------------
-export interface ProfileNameProps
-  extends Assign<HTMLStyledProps<'h2'>, PolymorphicProps>, UnstyledProps {}
+export interface ProfileNameProps extends Assign<
+  HTMLStyledProps<'h2'>,
+  PolymorphicProps
+> {}
 
 export const ProfileName = withSlotContext<
   HTMLHeadingElement,
@@ -42,8 +43,10 @@ export const ProfileName = withSlotContext<
 >(ark.h2, 'name')
 
 // -------------------- Title --------------------
-export interface ProfileTitleProps
-  extends Assign<HTMLStyledProps<'h3'>, PolymorphicProps>, UnstyledProps {}
+export interface ProfileTitleProps extends Assign<
+  HTMLStyledProps<'h3'>,
+  PolymorphicProps
+> {}
 
 export const ProfileTitle = withSlotContext<
   HTMLHeadingElement,
@@ -51,8 +54,10 @@ export const ProfileTitle = withSlotContext<
 >(ark.h3, 'title')
 
 // -------------------- AvatarWrapper --------------------
-export interface ProfileAvatarWrapperProps
-  extends Assign<HTMLStyledProps<'div'>, PolymorphicProps>, UnstyledProps {}
+export interface ProfileAvatarWrapperProps extends Assign<
+  HTMLStyledProps<'div'>,
+  PolymorphicProps
+> {}
 
 export const ProfileAvatarWrapper = withSlotContext<
   HTMLDivElement,

--- a/packages/fidely-ui/src/components/select/select.tsx
+++ b/packages/fidely-ui/src/components/select/select.tsx
@@ -2,7 +2,7 @@
 
 import type { Assign, CollectionItem } from '@ark-ui/react'
 import { Select as ArkSelect } from '@ark-ui/react/select'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { select, type SelectVariantProps } from 'styled-system/recipes'
 
 import { makeStyleContext } from '../../system/make-style-context'
@@ -12,13 +12,12 @@ import { FiCaretDownIcon } from '../../icons/FiCaretDownIcon'
 const { withSlotProvider, withSlotContext } = makeStyleContext(select)
 
 // -------------------- RootProvider --------------------
-export interface SelectRootProviderProps<T extends CollectionItem = any>
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkSelect.RootProviderBaseProps<T>>,
-      SelectVariantProps
-    >,
-    UnstyledProps {}
+export interface SelectRootProviderProps<
+  T extends CollectionItem = any,
+> extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkSelect.RootProviderBaseProps<T>>,
+  SelectVariantProps
+> {}
 
 export const SelectRootProvider = withSlotProvider<
   HTMLDivElement,
@@ -26,13 +25,10 @@ export const SelectRootProvider = withSlotProvider<
 >(ArkSelect.RootProvider, 'root')
 
 // -------------------- Root --------------------
-export interface SelectRootProps<T extends CollectionItem = any>
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkSelect.RootBaseProps<T>>,
-      SelectVariantProps
-    >,
-    UnstyledProps {}
+export interface SelectRootProps<T extends CollectionItem = any> extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkSelect.RootBaseProps<T>>,
+  SelectVariantProps
+> {}
 
 export const SelectRoot = withSlotProvider<HTMLDivElement, SelectRootProps>(
   ArkSelect.Root,
@@ -40,10 +36,10 @@ export const SelectRoot = withSlotProvider<HTMLDivElement, SelectRootProps>(
 )
 
 // -------------------- Control --------------------
-export interface SelectControlProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkSelect.ControlBaseProps>,
-    UnstyledProps {}
+export interface SelectControlProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkSelect.ControlBaseProps
+> {}
 
 export const SelectControl = withSlotContext<
   HTMLDivElement,
@@ -51,10 +47,10 @@ export const SelectControl = withSlotContext<
 >(ArkSelect.Control, 'control')
 
 // -------------------- Content --------------------
-export interface SelectContentProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkSelect.ContentBaseProps>,
-    UnstyledProps {}
+export interface SelectContentProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkSelect.ContentBaseProps
+> {}
 
 export const SelectContent = withSlotContext<
   HTMLDivElement,
@@ -62,10 +58,10 @@ export const SelectContent = withSlotContext<
 >(ArkSelect.Content, 'content')
 
 // -------------------- ClearTrigger --------------------
-export interface SelectClearTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkSelect.ClearTriggerBaseProps>,
-    UnstyledProps {
+export interface SelectClearTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkSelect.ClearTriggerBaseProps
+> {
   idleIcon?: React.ReactNode
 }
 
@@ -83,10 +79,10 @@ export const SelectClearTrigger = withSlotContext<
 }, 'clearTrigger')
 
 // -------------------- Trigger --------------------
-export interface SelectTriggerProps
-  extends
-    Assign<HTMLStyledProps<'button'>, ArkSelect.TriggerBaseProps>,
-    UnstyledProps {}
+export interface SelectTriggerProps extends Assign<
+  HTMLStyledProps<'button'>,
+  ArkSelect.TriggerBaseProps
+> {}
 
 export const SelectTrigger = withSlotContext<
   HTMLButtonElement,
@@ -94,10 +90,10 @@ export const SelectTrigger = withSlotContext<
 >(ArkSelect.Trigger, 'trigger')
 
 // -------------------- Indicator --------------------
-export interface SelectIndicatorProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkSelect.IndicatorBaseProps>,
-    UnstyledProps {
+export interface SelectIndicatorProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkSelect.IndicatorBaseProps
+> {
   idleIcon?: React.ReactNode
 }
 
@@ -113,8 +109,7 @@ export const SelectIndicator = withSlotContext<
 }, 'indicator')
 
 // -------------------- IndicatorGroup --------------------
-export interface SelectIndicatorGroupProps
-  extends HTMLStyledProps<'div'>, UnstyledProps {}
+export interface SelectIndicatorGroupProps extends HTMLStyledProps<'div'> {}
 
 export const SelectIndicatorGroup = withSlotContext<
   HTMLDivElement,
@@ -122,10 +117,10 @@ export const SelectIndicatorGroup = withSlotContext<
 >('div', 'indicatorGroup')
 
 // -------------------- Label --------------------
-export interface SelectLabelProps
-  extends
-    Assign<HTMLStyledProps<'label'>, ArkSelect.LabelBaseProps>,
-    UnstyledProps {}
+export interface SelectLabelProps extends Assign<
+  HTMLStyledProps<'label'>,
+  ArkSelect.LabelBaseProps
+> {}
 
 export const SelectLabel = withSlotContext<HTMLLabelElement, SelectLabelProps>(
   ArkSelect.Label,
@@ -133,10 +128,10 @@ export const SelectLabel = withSlotContext<HTMLLabelElement, SelectLabelProps>(
 )
 
 // -------------------- Item --------------------
-export interface SelectItemProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkSelect.ItemBaseProps>,
-    UnstyledProps {}
+export interface SelectItemProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkSelect.ItemBaseProps
+> {}
 
 export const SelectItem = withSlotContext<HTMLDivElement, SelectItemProps>(
   ArkSelect.Item,
@@ -144,10 +139,10 @@ export const SelectItem = withSlotContext<HTMLDivElement, SelectItemProps>(
 )
 
 // -------------------- ItemText --------------------
-export interface SelectItemTextProps
-  extends
-    Assign<HTMLStyledProps<'span'>, ArkSelect.ItemTextBaseProps>,
-    UnstyledProps {}
+export interface SelectItemTextProps extends Assign<
+  HTMLStyledProps<'span'>,
+  ArkSelect.ItemTextBaseProps
+> {}
 
 export const SelectItemText = withSlotContext<
   HTMLSpanElement,
@@ -155,10 +150,10 @@ export const SelectItemText = withSlotContext<
 >(ArkSelect.ItemText, 'itemText')
 
 // -------------------- ItemGroup --------------------
-export interface SelectItemGroupProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkSelect.ItemGroupBaseProps>,
-    UnstyledProps {}
+export interface SelectItemGroupProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkSelect.ItemGroupBaseProps
+> {}
 
 export const SelectItemGroup = withSlotContext<
   HTMLDivElement,
@@ -166,10 +161,10 @@ export const SelectItemGroup = withSlotContext<
 >(ArkSelect.ItemGroup, 'itemGroup')
 
 // -------------------- ItemGroupLabel --------------------
-export interface SelectItemGroupLabelProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkSelect.ItemGroupLabelBaseProps>,
-    UnstyledProps {}
+export interface SelectItemGroupLabelProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkSelect.ItemGroupLabelBaseProps
+> {}
 
 export const SelectItemGroupLabel = withSlotContext<
   HTMLDivElement,
@@ -177,10 +172,10 @@ export const SelectItemGroupLabel = withSlotContext<
 >(ArkSelect.ItemGroupLabel, 'itemGroupLabel')
 
 // -------------------- ItemIndicator --------------------
-export interface SelectItemIndicatorProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkSelect.ItemIndicatorBaseProps>,
-    UnstyledProps {}
+export interface SelectItemIndicatorProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkSelect.ItemIndicatorBaseProps
+> {}
 
 export const SelectItemIndicator = withSlotContext<
   HTMLDivElement,
@@ -188,10 +183,10 @@ export const SelectItemIndicator = withSlotContext<
 >(ArkSelect.ItemIndicator, 'itemIndicator')
 
 // -------------------- List --------------------
-export interface SelectListProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkSelect.ListBaseProps>,
-    UnstyledProps {}
+export interface SelectListProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkSelect.ListBaseProps
+> {}
 
 export const SelectList = withSlotContext<HTMLDivElement, SelectListProps>(
   ArkSelect.List,
@@ -199,10 +194,10 @@ export const SelectList = withSlotContext<HTMLDivElement, SelectListProps>(
 )
 
 // -------------------- Positioner --------------------
-export interface SelectPositionerProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkSelect.PositionerBaseProps>,
-    UnstyledProps {}
+export interface SelectPositionerProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkSelect.PositionerBaseProps
+> {}
 
 export const SelectPositioner = withSlotContext<
   HTMLDivElement,
@@ -210,10 +205,10 @@ export const SelectPositioner = withSlotContext<
 >(ArkSelect.Positioner, 'positioner')
 
 // -------------------- ValueText --------------------
-export interface SelectValueTextProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkSelect.ValueTextBaseProps>,
-    UnstyledProps {}
+export interface SelectValueTextProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkSelect.ValueTextBaseProps
+> {}
 
 export const SelectValueText = withSlotContext<
   HTMLDivElement,

--- a/packages/fidely-ui/src/components/stack/hstack.tsx
+++ b/packages/fidely-ui/src/components/stack/hstack.tsx
@@ -3,7 +3,8 @@
 import { forwardRef } from 'react'
 import { type PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
-import { HTMLStyledProps, styled } from 'styled-system/jsx'
+import { styled } from 'styled-system/jsx'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { hstack, type HstackStyles } from 'styled-system/patterns'
 
 import { splitProps } from '../../utils/split-props'

--- a/packages/fidely-ui/src/components/switch/switch.tsx
+++ b/packages/fidely-ui/src/components/switch/switch.tsx
@@ -2,7 +2,7 @@
 
 import type { Assign } from '@ark-ui/react'
 import { Switch as ArkSwitch } from '@ark-ui/react/switch'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 import {
   switchRecipe,
   type SwitchRecipeVariantProps,
@@ -13,13 +13,10 @@ import { makeStyleContext } from '../../system/make-style-context'
 const { withSlotProvider, withSlotContext } = makeStyleContext(switchRecipe)
 
 // -------------------- Root Provider --------------------
-export interface SwitchRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'label'>, ArkSwitch.RootProviderBaseProps>,
-      SwitchRecipeVariantProps
-    >,
-    UnstyledProps {}
+export interface SwitchRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'label'>, ArkSwitch.RootProviderBaseProps>,
+  SwitchRecipeVariantProps
+> {}
 
 export const SwitchRootProvider = withSlotProvider<
   HTMLLabelElement,
@@ -27,13 +24,10 @@ export const SwitchRootProvider = withSlotProvider<
 >(ArkSwitch.RootProvider, 'root')
 
 // -------------------- Root --------------------
-export interface SwitchRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'label'>, ArkSwitch.RootBaseProps>,
-      SwitchRecipeVariantProps
-    >,
-    UnstyledProps {}
+export interface SwitchRootProps extends Assign<
+  Assign<HTMLStyledProps<'label'>, ArkSwitch.RootBaseProps>,
+  SwitchRecipeVariantProps
+> {}
 
 export const SwitchRoot = withSlotProvider<HTMLLabelElement, SwitchRootProps>(
   ArkSwitch.Root,
@@ -41,10 +35,10 @@ export const SwitchRoot = withSlotProvider<HTMLLabelElement, SwitchRootProps>(
 )
 
 // -------------------- Control --------------------
-export interface SwitchControlProps
-  extends
-    Assign<HTMLStyledProps<'span'>, ArkSwitch.ControlBaseProps>,
-    UnstyledProps {}
+export interface SwitchControlProps extends Assign<
+  HTMLStyledProps<'span'>,
+  ArkSwitch.ControlBaseProps
+> {}
 
 export const SwitchControl = withSlotContext<
   HTMLSpanElement,
@@ -52,10 +46,10 @@ export const SwitchControl = withSlotContext<
 >(ArkSwitch.Control, 'control')
 
 // -------------------- Thumb --------------------
-export interface SwitchThumbProps
-  extends
-    Assign<HTMLStyledProps<'span'>, ArkSwitch.ThumbBaseProps>,
-    UnstyledProps {}
+export interface SwitchThumbProps extends Assign<
+  HTMLStyledProps<'span'>,
+  ArkSwitch.ThumbBaseProps
+> {}
 
 export const SwitchThumb = withSlotContext<HTMLSpanElement, SwitchThumbProps>(
   ArkSwitch.Thumb,
@@ -63,10 +57,10 @@ export const SwitchThumb = withSlotContext<HTMLSpanElement, SwitchThumbProps>(
 )
 
 // -------------------- Label --------------------
-export interface SwitchLabelProps
-  extends
-    Assign<HTMLStyledProps<'span'>, ArkSwitch.LabelBaseProps>,
-    UnstyledProps {}
+export interface SwitchLabelProps extends Assign<
+  HTMLStyledProps<'span'>,
+  ArkSwitch.LabelBaseProps
+> {}
 
 export const SwitchLabel = withSlotContext<HTMLSpanElement, SwitchLabelProps>(
   ArkSwitch.Label,

--- a/packages/fidely-ui/src/components/table/table.tsx
+++ b/packages/fidely-ui/src/components/table/table.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from 'react'
 import type { Assign, PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
 import { styled } from 'styled-system/jsx'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { table, type TableVariantProps } from 'styled-system/recipes'
 import { cx } from 'styled-system/css'
 
@@ -16,8 +16,7 @@ const { withSlotProvider, withSlotContext } = makeStyleContext(table)
 export interface TableRootProps
   extends
     Assign<HTMLStyledProps<'table'>, PolymorphicProps>,
-    TableVariantProps,
-    UnstyledProps {}
+    TableVariantProps {}
 
 export const TableRoot = withSlotProvider<HTMLTableElement, TableRootProps>(
   ark.table,
@@ -25,8 +24,10 @@ export const TableRoot = withSlotProvider<HTMLTableElement, TableRootProps>(
 )
 
 // -------------------- Body --------------------
-export interface TableBodyProps
-  extends Assign<HTMLStyledProps<'tbody'>, PolymorphicProps>, UnstyledProps {}
+export interface TableBodyProps extends Assign<
+  HTMLStyledProps<'tbody'>,
+  PolymorphicProps
+> {}
 
 export const TableBody = withSlotContext<
   HTMLTableSectionElement,
@@ -34,8 +35,10 @@ export const TableBody = withSlotContext<
 >(ark.tbody, 'body')
 
 // -------------------- Header --------------------
-export interface TableHeaderProps
-  extends Assign<HTMLStyledProps<'thead'>, PolymorphicProps>, UnstyledProps {}
+export interface TableHeaderProps extends Assign<
+  HTMLStyledProps<'thead'>,
+  PolymorphicProps
+> {}
 
 export const TableHeader = withSlotContext<
   HTMLTableSectionElement,
@@ -43,8 +46,10 @@ export const TableHeader = withSlotContext<
 >(ark.thead, 'header')
 
 // -------------------- Footer --------------------
-export interface TableFooterProps
-  extends Assign<HTMLStyledProps<'tfoot'>, PolymorphicProps>, UnstyledProps {}
+export interface TableFooterProps extends Assign<
+  HTMLStyledProps<'tfoot'>,
+  PolymorphicProps
+> {}
 
 export const TableFooter = withSlotContext<
   HTMLTableSectionElement,
@@ -52,8 +57,10 @@ export const TableFooter = withSlotContext<
 >(ark.tfoot, 'footer')
 
 // -------------------- Row --------------------
-export interface TableRowProps
-  extends Assign<HTMLStyledProps<'tr'>, PolymorphicProps>, UnstyledProps {}
+export interface TableRowProps extends Assign<
+  HTMLStyledProps<'tr'>,
+  PolymorphicProps
+> {}
 
 export const TableRow = withSlotContext<HTMLTableSectionElement, TableRowProps>(
   ark.tr,
@@ -61,8 +68,10 @@ export const TableRow = withSlotContext<HTMLTableSectionElement, TableRowProps>(
 )
 
 // -------------------- HeadCell --------------------
-export interface TableHeadCellProps
-  extends Assign<HTMLStyledProps<'th'>, PolymorphicProps>, UnstyledProps {}
+export interface TableHeadCellProps extends Assign<
+  HTMLStyledProps<'th'>,
+  PolymorphicProps
+> {}
 
 export const TableHeadCell = withSlotContext<
   HTMLTableSectionElement,
@@ -70,8 +79,10 @@ export const TableHeadCell = withSlotContext<
 >(ark.th, 'headCell')
 
 // -------------------- Cell --------------------
-export interface TableCellProps
-  extends Assign<HTMLStyledProps<'td'>, PolymorphicProps>, UnstyledProps {}
+export interface TableCellProps extends Assign<
+  HTMLStyledProps<'td'>,
+  PolymorphicProps
+> {}
 
 export const TableCell = withSlotContext<HTMLTableCellElement, TableCellProps>(
   ark.td,
@@ -79,8 +90,10 @@ export const TableCell = withSlotContext<HTMLTableCellElement, TableCellProps>(
 )
 
 // -------------------- Caption --------------------
-export interface TableCaptionProps
-  extends Assign<HTMLStyledProps<'caption'>, PolymorphicProps>, UnstyledProps {}
+export interface TableCaptionProps extends Assign<
+  HTMLStyledProps<'caption'>,
+  PolymorphicProps
+> {}
 
 export const TableCaption = withSlotContext<
   HTMLTableCaptionElement,
@@ -88,8 +101,7 @@ export const TableCaption = withSlotContext<
 >(ark.caption, 'caption')
 
 // -------------------- ScrollArea --------------------
-export interface TableScrollAreaProps
-  extends HTMLStyledProps<'div'>, UnstyledProps {}
+export interface TableScrollAreaProps extends HTMLStyledProps<'div'> {}
 
 export const TableScrollArea = forwardRef<HTMLDivElement, TableScrollAreaProps>(
   function TableScrollArea(props, ref) {

--- a/packages/fidely-ui/src/components/tabs/tabs.tsx
+++ b/packages/fidely-ui/src/components/tabs/tabs.tsx
@@ -2,7 +2,7 @@
 
 import { Tabs as ArkTabs } from '@ark-ui/react/tabs'
 import { type Assign } from '@ark-ui/react'
-import type { HTMLStyledProps, UnstyledProps } from 'styled-system/types'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { tabs, type TabsVariantProps } from 'styled-system/recipes'
 
 import { makeStyleContext } from '../../system/make-style-context'
@@ -10,26 +10,20 @@ import { makeStyleContext } from '../../system/make-style-context'
 const { withSlotProvider, withSlotContext } = makeStyleContext(tabs)
 
 // -------------------- Root --------------------
-export interface TabsRootProviderProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkTabs.RootProviderBaseProps>,
-      TabsVariantProps
-    >,
-    UnstyledProps {}
+export interface TabsRootProviderProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkTabs.RootProviderBaseProps>,
+  TabsVariantProps
+> {}
 
 export const TabsRootProvider = withSlotProvider<
   HTMLDivElement,
   TabsRootProviderProps
 >(ArkTabs.RootProvider, 'root')
 
-export interface TabsRootProps
-  extends
-    Assign<
-      Assign<HTMLStyledProps<'div'>, ArkTabs.RootBaseProps>,
-      TabsVariantProps
-    >,
-    UnstyledProps {}
+export interface TabsRootProps extends Assign<
+  Assign<HTMLStyledProps<'div'>, ArkTabs.RootBaseProps>,
+  TabsVariantProps
+> {}
 
 export const TabsRoot = withSlotProvider<HTMLDivElement, TabsRootProps>(
   ArkTabs.Root,
@@ -37,10 +31,10 @@ export const TabsRoot = withSlotProvider<HTMLDivElement, TabsRootProps>(
 )
 
 // -------------------- content --------------------
-export interface TabContentProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkTabs.ContentBaseProps>,
-    UnstyledProps {}
+export interface TabContentProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkTabs.ContentBaseProps
+> {}
 
 export const TabContent = withSlotContext<HTMLDivElement, TabContentProps>(
   ArkTabs.Content,
@@ -48,10 +42,10 @@ export const TabContent = withSlotContext<HTMLDivElement, TabContentProps>(
 )
 
 // -------------------- indicator --------------------
-export interface TabIndicatorProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkTabs.IndicatorBaseProps>,
-    UnstyledProps {}
+export interface TabIndicatorProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkTabs.IndicatorBaseProps
+> {}
 
 export const TabIndicator = withSlotContext<HTMLDivElement, TabIndicatorProps>(
   ArkTabs.Indicator,
@@ -59,10 +53,10 @@ export const TabIndicator = withSlotContext<HTMLDivElement, TabIndicatorProps>(
 )
 
 // -------------------- list --------------------
-export interface TabListProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkTabs.ListBaseProps>,
-    UnstyledProps {}
+export interface TabListProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkTabs.ListBaseProps
+> {}
 
 export const TabList = withSlotContext<HTMLDivElement, TabListProps>(
   ArkTabs.List,
@@ -70,10 +64,10 @@ export const TabList = withSlotContext<HTMLDivElement, TabListProps>(
 )
 
 // -------------------- trigger --------------------
-export interface TabTriggerProps
-  extends
-    Assign<HTMLStyledProps<'div'>, ArkTabs.TriggerBaseProps>,
-    UnstyledProps {}
+export interface TabTriggerProps extends Assign<
+  HTMLStyledProps<'div'>,
+  ArkTabs.TriggerBaseProps
+> {}
 
 export const TabTrigger = withSlotContext<HTMLButtonElement, TabTriggerProps>(
   ArkTabs.Trigger,

--- a/packages/fidely-ui/src/components/wrap/index.tsx
+++ b/packages/fidely-ui/src/components/wrap/index.tsx
@@ -3,7 +3,8 @@
 import { forwardRef } from 'react'
 import { type PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
-import { HTMLStyledProps, styled } from 'styled-system/jsx'
+import { styled } from 'styled-system/jsx'
+import { type HTMLStyledProps } from 'styled-system/types'
 import { wrap, type WrapProperties } from 'styled-system/patterns'
 
 import { splitProps } from '../../utils/split-props'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined component prop type definitions across UI components for cleaner TypeScript support.
  * Reorganized internal type imports for better code organization.

* **Improvements**
  * Enhanced default icon support for interactive components (checkboxes, clipboard, select, menu).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->