### PR TITLE
refactor(card): make CardDescription semantic paragraph element

### DIFF
--- a/.changeset/public-breads-think.md
+++ b/.changeset/public-breads-think.md
@@ -1,0 +1,5 @@
+---
+'@fidely-ui/react': patch
+---
+
+Change **`CardDescription`** default element from `div` to `p` while preserving polymorphism

--- a/packages/fidely-ui/src/components/card/card.tsx
+++ b/packages/fidely-ui/src/components/card/card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { Assign, HTMLArkProps, PolymorphicProps } from '@ark-ui/react'
+import type { Assign, PolymorphicProps } from '@ark-ui/react'
 import { ark } from '@ark-ui/react/factory'
 import { type HTMLStyledProps } from 'styled-system/types'
 import { card, type CardVariantProps } from 'styled-system/recipes'
@@ -48,7 +48,7 @@ export const CardHeader = withSlotContext<HTMLDivElement, CardHeaderProps>(
 // -------------------- Title --------------------
 export interface CardTitleProps extends Assign<
   HTMLStyledProps<'h4'>,
-  HTMLArkProps<'h4'>
+  PolymorphicProps
 > {}
 
 export const CardTitle = withSlotContext<HTMLHeadingElement, CardTitleProps>(
@@ -58,14 +58,14 @@ export const CardTitle = withSlotContext<HTMLHeadingElement, CardTitleProps>(
 
 // -------------------- Description --------------------
 export interface CardDescriptionProps extends Assign<
-  HTMLStyledProps<'div'>,
+  HTMLStyledProps<'p'>,
   PolymorphicProps
 > {}
 
 export const CardDescription = withSlotContext<
-  HTMLDivElement,
+  HTMLParagraphElement,
   CardDescriptionProps
->(ark.div, 'description')
+>(ark.p, 'description')
 
 // -------------------- Footer --------------------
 export interface CardFooterProps extends Assign<


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated CardDescription component to use semantic paragraph element (`<p>`) instead of div as the default, while preserving polymorphic flexibility.
  * Enhanced type definitions for CardTitle and CardDescription components for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->