### PR TITLE
fix(table, clipboard): correct slot element typing mismatch

### DIFF
--- a/.changeset/big-needles-share.md
+++ b/.changeset/big-needles-share.md
@@ -1,0 +1,5 @@
+---
+'@fidely-ui/react': patch
+---
+
+Fix slot typing mismatches in `Table` and `Clipboard` components.

--- a/packages/fidely-ui/src/components/clipboard/clipboard.tsx
+++ b/packages/fidely-ui/src/components/clipboard/clipboard.tsx
@@ -52,7 +52,7 @@ export interface ClipboardTriggerProps extends Assign<
 > {}
 
 export const ClipboardTrigger = withSlotContext<
-  HTMLDivElement,
+  HTMLButtonElement,
   ClipboardTriggerProps
 >(ArkClipboard.Trigger, 'trigger')
 
@@ -90,7 +90,7 @@ export interface ClipboardInputProps extends Assign<
 > {}
 
 export const ClipboardInput = withSlotContext<
-  HTMLDivElement,
+  HTMLInputElement,
   ClipboardInputProps
 >(ArkClipboard.Input, 'input')
 
@@ -101,7 +101,7 @@ export interface ClipboardLabelProps extends Assign<
 > {}
 
 export const ClipboardLabel = withSlotContext<
-  HTMLDivElement,
+  HTMLLabelElement,
   ClipboardLabelProps
 >(ArkClipboard.Label, 'label')
 

--- a/packages/fidely-ui/src/components/password-input/password-input.tsx
+++ b/packages/fidely-ui/src/components/password-input/password-input.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import * as React from 'react'
 import type { Assign } from '@ark-ui/react'
 import { PasswordInput as ArkPasswordInput } from '@ark-ui/react/password-input'
 import {

--- a/packages/fidely-ui/src/components/table/table.tsx
+++ b/packages/fidely-ui/src/components/table/table.tsx
@@ -62,7 +62,7 @@ export interface TableRowProps extends Assign<
   PolymorphicProps
 > {}
 
-export const TableRow = withSlotContext<HTMLTableSectionElement, TableRowProps>(
+export const TableRow = withSlotContext<HTMLTableRowElement, TableRowProps>(
   ark.tr,
   'row'
 )
@@ -74,7 +74,7 @@ export interface TableHeadCellProps extends Assign<
 > {}
 
 export const TableHeadCell = withSlotContext<
-  HTMLTableSectionElement,
+  HTMLTableCellElement,
   TableHeadCellProps
 >(ark.th, 'headCell')
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript type definitions for Clipboard component slots to correctly reflect the underlying element types (Trigger, Input, Label).
  * Fixed TypeScript type definitions for Table component slots to accurately represent Row and HeadCell element types.
  * These corrections improve type accuracy and ensure proper IDE support when using these components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->