### PR TITLE
fix: Menu `Arrow` & `ArrowTip` styles not showing when used

### DIFF
--- a/.changeset/free-lilies-clean.md
+++ b/.changeset/free-lilies-clean.md
@@ -2,4 +2,4 @@
 '@fidely-ui/panda-preset': patch
 ---
 
-fix: `PasswordInput` `VisisbiltyTrigger` `left-top`, `left-bottom` radius and use default `Input` background
+fix: `PasswordInput` `VisibilityTrigger` `left-top`, `left-bottom` radius and use default `Input` background

--- a/.changeset/thick-rockets-vanish.md
+++ b/.changeset/thick-rockets-vanish.md
@@ -1,0 +1,5 @@
+---
+'@fidely-ui/panda-preset': patch
+---
+
+fix: **`Menu`** `Arrow` & `ArrowTip` styles not showing when used

--- a/apps/patherns/src/examples/menu/menu-basics.tsx
+++ b/apps/patherns/src/examples/menu/menu-basics.tsx
@@ -14,6 +14,10 @@ export const MenuBasics = () => {
       <Portal>
         <Menu.Positioner>
           <Menu.Content minW="160px">
+            <Menu.Arrow>
+              <Menu.ArrowTip />
+            </Menu.Arrow>
+
             <Menu.ItemGroup>
               <Menu.ItemGroupLabel>Workspace</Menu.ItemGroupLabel>
               <Menu.Separator />

--- a/packages/preset/src/theme/slot-recipe/menu.recipe.ts
+++ b/packages/preset/src/theme/slot-recipe/menu.recipe.ts
@@ -10,8 +10,9 @@ export const menuSlotRecipe = defineSlotRecipe({
 
   base: {
     content: {
+      '--menu-bg': 'colors.bg.default',
       outline: 0,
-      bg: 'bg.default',
+      bg: 'var(--menu-bg)',
       color: 'fg.default',
       borderRadius: 's2',
       overflowY: 'auto',
@@ -105,6 +106,15 @@ export const menuSlotRecipe = defineSlotRecipe({
       _focusVisible: {
         focusVisibleRing: 'outside',
       },
+    },
+
+    arrow: {
+      '--arrow-size': 'sizes.3',
+      '--arrow-background': 'var(--menu-bg)',
+    },
+    arrowTip: {
+      borderTopWidth: '0.5px',
+      borderLeftWidth: '0.5px',
     },
   },
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Menu, Arrow, and ArrowTip components not displaying styles correctly

* **Documentation**
  * Corrected typo in changelog documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->