### PR TITLE
feat(pin-input): add `PinInput.Group` and `PinInput.Separator`

### DIFF
--- a/.changeset/eighty-melons-cut.md
+++ b/.changeset/eighty-melons-cut.md
@@ -1,0 +1,6 @@
+---
+'@fidely-ui/react': minor
+'@fidely-ui/panda-preset': minor
+---
+
+feat(pin-input): add `PinInput.Group` and `PinInput.Separator` components with styling

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prepare": "panda codegen --clean",
     "dev:content": "velite --watch",
-    "dev:next": "next dev",
+    "dev:next": "rm -rf .next && next dev",
     "build:content": "velite --clean",
     "build:next": "next build",
     "dev": "pnpm run dev:content & pnpm run dev:next",

--- a/packages/fidely-ui/src/components/pin-input/index.ts
+++ b/packages/fidely-ui/src/components/pin-input/index.ts
@@ -4,6 +4,8 @@ export {
   PinInputInput,
   PinInputLabel,
   PinInputControl,
+  PinInputInputGroup,
+  PinInputInputSeparator,
   PinInputHiddenInput,
   PinInputContext,
   PinInputValueChangeDetails,
@@ -14,6 +16,8 @@ export type {
   PinInputInputProps,
   PinInputLabelProps,
   PinInputControlProps,
+  PinInputInputGroupProps,
+  PinInputInputSeparatorProps,
   PinInputRootProps,
 } from './pin-input'
 

--- a/packages/fidely-ui/src/components/pin-input/namespace.ts
+++ b/packages/fidely-ui/src/components/pin-input/namespace.ts
@@ -5,6 +5,8 @@ export {
   PinInputInput as Input,
   PinInputLabel as Label,
   PinInputControl as Control,
+  PinInputInputGroup as Group,
+  PinInputInputSeparator as Separator,
   PinInputContext as Context,
   PinInputValueChangeDetails as ValueChangeDetails,
 } from './pin-input'
@@ -15,4 +17,6 @@ export type {
   PinInputLabelProps as LabelProps,
   PinInputControlProps as ControlProps,
   PinInputRootProps as RootProps,
+  PinInputInputGroupProps as GroupProps,
+  PinInputInputSeparatorProps as SeparatorProps,
 } from './pin-input'

--- a/packages/fidely-ui/src/components/pin-input/pin-input.tsx
+++ b/packages/fidely-ui/src/components/pin-input/pin-input.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import type { Assign } from '@ark-ui/react'
+import type { Assign, PolymorphicProps } from '@ark-ui/react'
+import { ark } from '@ark-ui/react/factory'
 import { PinInput as ArkPinInput } from '@ark-ui/react/pin-input'
 import { pinInput, type PinInputVariantProps } from 'styled-system/recipes'
 import { type HTMLStyledProps } from 'styled-system/types'
@@ -59,6 +60,26 @@ export const PinInputInput = withSlotContext<
   HTMLInputElement,
   PinInputInputProps
 >(ArkPinInput.Input, 'input')
+
+export interface PinInputInputGroupProps extends Assign<
+  HTMLStyledProps<'div'>,
+  PolymorphicProps
+> {}
+
+export const PinInputInputGroup = withSlotContext<
+  HTMLDivElement,
+  PinInputInputGroupProps
+>(ark.div, 'group')
+
+export interface PinInputInputSeparatorProps extends Assign<
+  HTMLStyledProps<'hr'>,
+  PolymorphicProps
+> {}
+
+export const PinInputInputSeparator = withSlotContext<
+  HTMLHRElement,
+  PinInputInputSeparatorProps
+>(ark.hr, 'separator')
 
 export const PinInputHiddenInput = ArkPinInput.HiddenInput
 export const PinInputContext = ArkPinInput.Context

--- a/packages/preset/src/anatomy/anatomy.ts
+++ b/packages/preset/src/anatomy/anatomy.ts
@@ -162,7 +162,9 @@ export const pinInputAnatomy = anatomy('pin-input').parts(
   'root',
   'control',
   'label',
-  'input'
+  'input',
+  'separator',
+  'group'
 )
 
 export const popoverAnatomy = anatomy('popover').parts(

--- a/packages/preset/src/theme/slot-recipe/pinInput.recipe.ts
+++ b/packages/preset/src/theme/slot-recipe/pinInput.recipe.ts
@@ -32,6 +32,36 @@ export const pinInputSlotRecipe = defineSlotRecipe({
       textStyle: 'sm',
       fontWeight: 'medium',
     },
+    group: {
+      display: 'flex',
+      alignItems: 'center',
+      verticalAlign: 'middle',
+      gap: '0',
+
+      '& > input': {
+        borderRadius: '0',
+        marginLeft: '-1px',
+        _focusVisible: {
+          zIndex: '1',
+        },
+        '&:first-of-type': {
+          borderStartRadius: 's2',
+        },
+        '&:last-of-type': {
+          borderEndRadius: 's2',
+        },
+      },
+    },
+    separator: {
+      display: 'block',
+      border: 'none',
+      bg: 'border.default',
+      height: '1.5px',
+      width: '4',
+      mx: '1',
+      alignSelf: 'center',
+      flexShrink: 0,
+    },
   },
 
   variants: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pin-input component now includes `Group` and `Separator` subcomponents, enabling improved organizational control and visual separation of input fields within the component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->