### PR TITLE
refactor(clipboard): align indicator API with Ark UI

### DIFF
--- a/.changeset/funky-bikes-press.md
+++ b/.changeset/funky-bikes-press.md
@@ -1,0 +1,9 @@
+---
+'@fidely-ui/react': minor
+---
+
+Refactored `ClipboardIndicator` to improve API alignment
+
+- Replaced `idleIcon` prop with standard React `children`.
+- Replaced `copiedIcon` prop with the `copied` prop.
+- Integrated `FiCopy` and `FiCheck` as default fallbacks.

--- a/packages/fidely-ui/src/components/clipboard/clipboard.tsx
+++ b/packages/fidely-ui/src/components/clipboard/clipboard.tsx
@@ -59,26 +59,20 @@ export const ClipboardTrigger = withSlotContext<
 // -------------------- Indicator --------------------
 export interface ClipboardIndicatorProps extends Assign<
   HTMLStyledProps<'div'>,
-  ArkClipboard.IndicatorBaseProps
+  Omit<ArkClipboard.IndicatorBaseProps, 'copied'>
 > {
-  copiedIcon?: React.ReactNode
-  idleIcon?: React.ReactNode
+  copied?: React.ReactNode
 }
 
 export const ClipboardIndicator = withSlotContext<
   HTMLDivElement,
   ClipboardIndicatorProps
 >((props) => {
-  const {
-    copiedIcon = <FiCheck />,
-    idleIcon = <FiCopy />,
-    children,
-    ...rest
-  } = props
+  const { copied, children, ...rest } = props
 
   return (
-    <ArkClipboard.Indicator {...rest} copied={props.copied ?? copiedIcon}>
-      {children ?? idleIcon}
+    <ArkClipboard.Indicator copied={copied ?? <FiCheck />} {...rest}>
+      {children ?? <FiCopy />}
     </ArkClipboard.Indicator>
   )
 }, 'indicator')


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `ClipboardIndicator` component API updated. The `idleIcon` and `copiedIcon` props have been replaced with `children` (for idle content) and a `copied` prop (for copied state). FiCopy and FiCheck icons are now provided by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->