### PR TITLE
fix(combobox): `Combobox.Control` and `Combobox.Input` background to …

### DIFF
--- a/.changeset/eleven-buses-glow.md
+++ b/.changeset/eleven-buses-glow.md
@@ -1,0 +1,5 @@
+---
+'@fidely-ui/panda-preset': patch
+---
+
+fix(combobox): `Combobox.Control` and `Combobox.Input` background to default and spacing

--- a/packages/preset/src/theme/slot-recipe/combobox.recipe.ts
+++ b/packages/preset/src/theme/slot-recipe/combobox.recipe.ts
@@ -26,12 +26,10 @@ export const comboboxSlotRecipe = defineSlotRecipe({
       display: 'flex',
       alignItems: 'center',
       gap: '2',
-      px: '1.5',
-
+      px: 'var(--combobox-control--padding-x)',
       borderWidth: '1px',
       borderColor: 'border.default',
       borderRadius: 's2',
-      bg: 'bg.surface',
       '--default-color': 'colors.colorPalette.default',
       '--error-color': 'colors.border.error',
 
@@ -50,11 +48,8 @@ export const comboboxSlotRecipe = defineSlotRecipe({
       ...inputRecipe.base,
       flex: 1,
       minWidth: 0,
-
       minH: 'var(--combobox-input-height)',
       '--input-height': 'var(--combobox-input-height)',
-
-      bg: 'bg.surface',
       border: 'none',
 
       _focus: {
@@ -109,8 +104,8 @@ export const comboboxSlotRecipe = defineSlotRecipe({
     },
 
     itemGroupLabel: {
-      px: '3',
-      py: '2',
+      px: 'var(--combobox-item-padding-y)',
+      py: 'var(--combobox-item-padding-x)',
       fontWeight: 'medium',
       textStyle: 'xs',
       color: 'fg.muted',
@@ -152,8 +147,8 @@ export const comboboxSlotRecipe = defineSlotRecipe({
 
     empty: {
       textStyle: 'sm',
-      px: '3',
-      py: '2',
+      px: 'var(--combobox-item-padding-y)',
+      py: 'var(--combobox-item-padding-x)',
       color: 'fg.muted',
     },
     indicatorGroup: {
@@ -174,8 +169,9 @@ export const comboboxSlotRecipe = defineSlotRecipe({
       xs: {
         root: {
           '--combobox-input-height': 'sizes.8',
+          '--combobox-control--padding-x': 'spacing.2',
           '--combobox-item-padding-y': '2',
-          '--combobox-item-padding-x': '3.4',
+          '--combobox-item-padding-x': '2.5',
         },
         input: {
           textStyle: 'xs',
@@ -191,8 +187,9 @@ export const comboboxSlotRecipe = defineSlotRecipe({
       sm: {
         root: {
           '--combobox-input-height': 'sizes.9',
+          '--combobox-control--padding-x': 'spacing.2.5',
           '--combobox-item-padding-y': '2.5',
-          '--combobox-item-padding-x': '3.9',
+          '--combobox-item-padding-x': '3',
         },
         input: {
           textStyle: 'sm',
@@ -208,8 +205,9 @@ export const comboboxSlotRecipe = defineSlotRecipe({
       md: {
         root: {
           '--combobox-input-height': 'sizes.10',
+          '--combobox-control--padding-x': 'spacing.3',
           '--combobox-item-padding-y': '3',
-          '--combobox-item-padding-x': '4',
+          '--combobox-item-padding-x': '3.5',
         },
         input: {
           textStyle: 'sm',
@@ -225,8 +223,9 @@ export const comboboxSlotRecipe = defineSlotRecipe({
       lg: {
         root: {
           '--combobox-input-height': 'sizes.12',
+          '--combobox-control--padding-x': 'spacing.3.5',
           '--combobox-item-padding-y': '3',
-          '--combobox-item-padding-x': '4.9',
+          '--combobox-item-padding-x': '4',
         },
         input: {
           textStyle: 'md',
@@ -234,7 +233,7 @@ export const comboboxSlotRecipe = defineSlotRecipe({
         content: {
           '--combobox-item-padding-y': 'spacing.2',
           '--combobox-item-padding-x': 'spacing.3',
-          p: '1.5',
+          p: '1',
           textStyle: 'md',
         },
       },


### PR DESCRIPTION
…default and spacing

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed Combobox.Control and Combobox.Input background styling to use default colors instead of hardcoded values
* Improved and standardized spacing and padding across Combobox components for all sizes (xs, sm, md, lg)
* Enhanced visual consistency of combobox item groups and empty states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->