### PR TITLE
feat(select): Re-export ark select types, and `Select.Context`

### DIFF
--- a/.changeset/twelve-lands-do.md
+++ b/.changeset/twelve-lands-do.md
@@ -1,0 +1,5 @@
+---
+'@fidely-ui/react': patch
+---
+
+Re-export ark select types, and `Select.Context`

--- a/packages/fidely-ui/src/components/select/index.ts
+++ b/packages/fidely-ui/src/components/select/index.ts
@@ -4,6 +4,7 @@ export {
   SelectClearTrigger,
   SelectTrigger,
   SelectContent,
+  SelectContext,
   SelectControl,
   SelectHiddenSelect,
   SelectIndicator,
@@ -47,6 +48,12 @@ export {
   useSelectItemContext,
 } from '@ark-ui/react/select'
 
-export type { UseSelectProps, UseSelectReturn } from '@ark-ui/react/select'
+export type {
+  UseSelectProps,
+  UseSelectReturn,
+  SelectInteractOutsideEvent,
+  SelectFocusOutsideEvent,
+  SelectPointerDownOutsideEvent,
+} from '@ark-ui/react/select'
 
 export * as Select from './namespace'

--- a/packages/fidely-ui/src/components/select/namespace.ts
+++ b/packages/fidely-ui/src/components/select/namespace.ts
@@ -4,6 +4,7 @@ export {
   SelectClearTrigger as ClearTrigger,
   SelectTrigger as Trigger,
   SelectContent as Content,
+  SelectContext as Context,
   SelectControl as Control,
   SelectHiddenSelect as HiddenSelect,
   SelectIndicator as Indicator,
@@ -40,3 +41,9 @@ export {
   SelectValueTextProps as ValueTextProps,
   SelectIndicatorGroupProps as IndicatorGroupProps,
 } from './select'
+
+export type {
+  SelectInteractOutsideEvent as InteractOutsideEvent,
+  SelectFocusOutsideEvent as FocusOutsideEvent,
+  SelectPointerDownOutsideEvent as PointerDownOutsideEvent,
+} from '@ark-ui/react/select'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing fidely ui users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Select component exports to include context and additional event types, enabling more flexible integration with select functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->